### PR TITLE
[ADD] Added ServerIPv4 config field.

### DIFF
--- a/context/smf_context.go
+++ b/context/smf_context.go
@@ -3,6 +3,7 @@ package context
 import (
 	"fmt"
 	"net"
+	"os"
 
 	"free5gc/lib/openapi/Nnrf_NFDiscovery"
 	"free5gc/lib/openapi/Nnrf_NFManagement"
@@ -25,6 +26,8 @@ var smfContext SMFContext
 
 type SMFContext struct {
 	Name         string
+	ServerIPv4	string
+
 	NfInstanceID string
 
 	URIScheme   models.UriScheme
@@ -72,6 +75,16 @@ func InitSmfContext(config *factory.Config) {
 		smfContext.Name = configuration.SmfName
 	}
 
+	smfContext.ServerIPv4 = os.Getenv(configuration.ServerIPv4)
+	if smfContext.ServerIPv4 == "" {
+		logger.CtxLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Trying to parse it as string.")
+		smfContext.ServerIPv4 = configuration.ServerIPv4
+		if smfContext.ServerIPv4 == "" {
+			logger.CtxLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
+			smfContext.ServerIPv4 = "127.0.0.1"
+		}
+	}
+
 	sbi := configuration.Sbi
 	smfContext.URIScheme = models.UriScheme(sbi.Scheme)
 	smfContext.HTTPAddress = "127.0.0.1" // default localhost
@@ -92,12 +105,18 @@ func InitSmfContext(config *factory.Config) {
 	if configuration.NrfUri != "" {
 		smfContext.NrfUri = configuration.NrfUri
 	} else {
-		smfContext.NrfUri = fmt.Sprintf("%s://%s:%d", smfContext.URIScheme, smfContext.HTTPAddress, 29510)
+		logger.CtxLog.Error("NRF Uri is empty! Using localhost as NRF IPv4 address.")
+		smfContext.NrfUri = fmt.Sprintf("%s://%s:%d", smfContext.URIScheme, "127.0.0.1", 29510)
 	}
 
 	if pfcp := configuration.PFCP; pfcp != nil {
 		if pfcp.Port == 0 {
 			pfcp.Port = pfcpUdp.PFCP_PORT
+		}
+		pfcp.Addr = os.Getenv(pfcp.Addr)
+		if pfcp.Addr == "" {
+			logger.CtxLog.Warn("Problem parsing PFCP IPv4 address from ENV Variable. Using the localhost address as default.")
+			pfcp.Addr = "127.0.0.1"
 		}
 		addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", pfcp.Addr, pfcp.Port))
 		if err != nil {

--- a/factory/config.go
+++ b/factory/config.go
@@ -21,6 +21,8 @@ type Info struct {
 type Configuration struct {
 	SmfName string `yaml:"smfName,omitempty"`
 
+	ServerIPv4 string `yaml:"serverIPv4,omitempty"`
+
 	Sbi *Sbi `yaml:"sbi,omitempty"`
 
 	PFCP *PFCP `yaml:"pfcp,omitempty"`

--- a/service/init.go
+++ b/service/init.go
@@ -166,7 +166,7 @@ func (smf *SMF) Start() {
 	time.Sleep(1000 * time.Millisecond)
 
 	go handler.Handle()
-	HTTPAddr := fmt.Sprintf("%s:%d", context.SMF_Self().HTTPAddress, context.SMF_Self().HTTPPort)
+	HTTPAddr := fmt.Sprintf("%s:%d", context.SMF_Self().ServerIPv4, context.SMF_Self().HTTPPort)
 	server, err := http2_util.NewServer(HTTPAddr, util.SmfLogPath, router)
 
 	if server == nil {


### PR DESCRIPTION
The `ServerIPv4` field will be used to specify the IP where the server will start.
The difference that this field makes is that now the NFs can advertise a service IP (which is different from the NodeIP) in Kubernetes.

These modifications were tested and no compatibility issues were found.

This PR comes after the discussion here: https://github.com/free5gc/free5gc/issues/49#issuecomment-640213366