### PR TITLE
Support pdu session establishment IEs

### DIFF
--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"encoding/hex"
 	"free5gc/lib/nas"
 	"free5gc/lib/nas/nasConvert"
 	"free5gc/lib/nas/nasMessage"
@@ -83,31 +84,60 @@ func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error)
 		pDUSessionEstablishmentAccept.PDUAddress.SetPDUAddressInformation(addr)
 	}
 
-	// pDUSessionEstablishmentAccept.AuthorizedQosFlowDescriptions = nasType.NewAuthorizedQosFlowDescriptions(nasMessage.PDUSessionEstablishmentAcceptAuthorizedQosFlowDescriptionsType)
-	// pDUSessionEstablishmentAccept.AuthorizedQosFlowDescriptions.SetLen(6)
-	// pDUSessionEstablishmentAccept.SetQoSFlowDescriptions([]uint8{0x09, 0x20, 0x41, 0x01, 0x01, 0x09})
+	pDUSessionEstablishmentAccept.AuthorizedQosFlowDescriptions = nasType.NewAuthorizedQosFlowDescriptions(nasMessage.PDUSessionEstablishmentAcceptAuthorizedQosFlowDescriptionsType)
+	pDUSessionEstablishmentAccept.AuthorizedQosFlowDescriptions.SetLen(6)
+	pDUSessionEstablishmentAccept.SetQoSFlowDescriptions([]uint8{uint8(authDefQos.Var5qi), 0x20, 0x41, 0x01, 0x01, 0x09})
+
+	pDUSessionEstablishmentAccept.Cause5GSM = nasType.NewCause5GSM(nasMessage.PDUSessionEstablishmentAcceptCause5GSMType)
+	pDUSessionEstablishmentAccept.Cause5GSM.SetCauseValue(nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed)
+
+	byteArray, _ := hex.DecodeString(smContext.Snssai.Sd)
+	var sd [3]uint8
+	copy(sd[:], byteArray)
+	pDUSessionEstablishmentAccept.SNSSAI = nasType.NewSNSSAI(nasMessage.ULNASTransportSNSSAIType)
+	pDUSessionEstablishmentAccept.SNSSAI.SetLen(4)
+	pDUSessionEstablishmentAccept.SNSSAI.SetSST(uint8(smContext.Snssai.Sst))
+	pDUSessionEstablishmentAccept.SNSSAI.SetSD(sd)
+
+	dnn := []byte(smContext.Dnn)
+	pDUSessionEstablishmentAccept.DNN = nasType.NewDNN(nasMessage.ULNASTransportDNNType)
+	pDUSessionEstablishmentAccept.DNN.SetLen(uint8(len(dnn)))
+	pDUSessionEstablishmentAccept.DNN.SetDNN(dnn)
 
 	if smContext.ProtocolConfigurationOptions.DNSIPv4Request || smContext.ProtocolConfigurationOptions.DNSIPv6Request {
 		dnnInfo, exist := SMF_Self().DNNInfo[smContext.Dnn]
 		if !exist {
 			logger.GsmLog.Warnf("No default DNS IP for DNN [%s]\n", smContext.Dnn)
-		} else {
+		}
+
+		if exist || smContext.ProtocolConfigurationOptions.IPv4LinkMTURequest {
 			pDUSessionEstablishmentAccept.ExtendedProtocolConfigurationOptions = nasType.NewExtendedProtocolConfigurationOptions(nasMessage.PDUSessionEstablishmentAcceptExtendedProtocolConfigurationOptionsType)
 			protocolConfigurationOptions := nasConvert.NewProtocolConfigurationOptions()
 
-			if smContext.ProtocolConfigurationOptions.DNSIPv4Request {
-				DNSIPv4Addr := net.ParseIP(dnnInfo.DNS.IPv4Addr)
-				err := protocolConfigurationOptions.AddDNSServerIPv4Address(DNSIPv4Addr)
-				if err != nil {
-					logger.GsmLog.Warnln("Error while adding DNS IPv4 Addr: ", err)
+			// DNS IP
+			if exist {
+				if smContext.ProtocolConfigurationOptions.DNSIPv4Request {
+					DNSIPv4Addr := net.ParseIP(dnnInfo.DNS.IPv4Addr)
+					err := protocolConfigurationOptions.AddDNSServerIPv4Address(DNSIPv4Addr)
+					if err != nil {
+						logger.GsmLog.Warnln("Error while adding DNS IPv4 Addr: ", err)
+					}
+				}
+
+				if smContext.ProtocolConfigurationOptions.DNSIPv6Request {
+					DNSIPv6Addr := net.ParseIP(dnnInfo.DNS.IPv6Addr)
+					err := protocolConfigurationOptions.AddDNSServerIPv6Address(DNSIPv6Addr)
+					if err != nil {
+						logger.GsmLog.Warnln("Error while adding DNS IPv6 Addr: ", err)
+					}
 				}
 			}
 
-			if smContext.ProtocolConfigurationOptions.DNSIPv6Request {
-				DNSIPv6Addr := net.ParseIP(dnnInfo.DNS.IPv6Addr)
-				err := protocolConfigurationOptions.AddDNSServerIPv6Address(DNSIPv6Addr)
+			// MTU
+			if smContext.ProtocolConfigurationOptions.IPv4LinkMTURequest {
+				err := protocolConfigurationOptions.AddIPv4LinkMTU(1400)
 				if err != nil {
-					logger.GsmLog.Warnln("Error while adding DNS IPv6 Addr: ", err)
+					logger.GsmLog.Warnln("Error while adding MTU: ", err)
 				}
 			}
 

--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -26,7 +26,7 @@ func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error)
 	pDUSessionEstablishmentAccept.SetPDUSessionID(uint8(smContext.PDUSessionID))
 	pDUSessionEstablishmentAccept.SetMessageType(nas.MsgTypePDUSessionEstablishmentAccept)
 	pDUSessionEstablishmentAccept.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
-	pDUSessionEstablishmentAccept.SetPTI(0x00)
+	pDUSessionEstablishmentAccept.SetPTI(smContext.Pti)
 
 	selectedPDUSessionType := nasConvert.PDUSessionTypeToModels(smContext.SelectedPDUSessionType)
 	if selectedPDUSessionType == models.PduSessionType_IPV4_V6 {
@@ -57,6 +57,7 @@ func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error)
 			Identifier:    0x01,
 			DQR:           0x01,
 			OperationCode: OperationCodeCreateNewQoSRule,
+			Precedence:    0xff,
 			QFI:           uint8(authDefQos.Var5qi),
 			PacketFilterList: []PacketFilter{
 				{
@@ -145,7 +146,6 @@ func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error)
 			pcoContentsLength := len(pcoContents)
 			pDUSessionEstablishmentAccept.ExtendedProtocolConfigurationOptions.SetLen(uint16(pcoContentsLength))
 			pDUSessionEstablishmentAccept.ExtendedProtocolConfigurationOptions.SetExtendedProtocolConfigurationOptionsContents(pcoContents)
-
 		}
 
 	}
@@ -153,7 +153,6 @@ func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error)
 }
 
 func BuildGSMPDUSessionReleaseCommand(smContext *SMContext) ([]byte, error) {
-
 	m := nas.NewMessage()
 	m.GsmMessage = nas.NewGsmMessage()
 	m.GsmHeader.SetMessageType(nas.MsgTypePDUSessionReleaseCommand)
@@ -164,7 +163,7 @@ func BuildGSMPDUSessionReleaseCommand(smContext *SMContext) ([]byte, error) {
 	pDUSessionReleaseCommand.SetMessageType(nas.MsgTypePDUSessionReleaseCommand)
 	pDUSessionReleaseCommand.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
 	pDUSessionReleaseCommand.SetPDUSessionID(uint8(smContext.PDUSessionID))
-	pDUSessionReleaseCommand.SetPTI(0x00)
+	pDUSessionReleaseCommand.SetPTI(smContext.Pti)
 	pDUSessionReleaseCommand.SetCauseValue(0x0)
 
 	return m.PlainNasEncode()

--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -179,7 +179,7 @@ func BuildGSMPDUSessionModificationCommand(smContext *SMContext) ([]byte, error)
 
 	pDUSessionModificationCommand.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
 	pDUSessionModificationCommand.SetPDUSessionID(uint8(smContext.PDUSessionID))
-	pDUSessionModificationCommand.SetPTI(0x00)
+	pDUSessionModificationCommand.SetPTI(smContext.Pti)
 	pDUSessionModificationCommand.SetMessageType(nas.MsgTypePDUSessionModificationCommand)
 	// pDUSessionModificationCommand.SetQosRule()
 	// pDUSessionModificationCommand.AuthorizedQosRules.SetLen()
@@ -204,7 +204,7 @@ func BuildGSMPDUSessionReleaseReject(smContext *SMContext) ([]byte, error) {
 	pDUSessionReleaseReject.SetMessageType(nas.MsgTypePDUSessionReleaseReject)
 	pDUSessionReleaseReject.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
 	pDUSessionReleaseReject.SetPDUSessionID(uint8(smContext.PDUSessionID))
-	pDUSessionReleaseReject.SetPTI(0x00)
+	pDUSessionReleaseReject.SetPTI(smContext.Pti)
 	// TODO: fix to real value
 	pDUSessionReleaseReject.SetCauseValue(nasMessage.Cause5GSMRequestRejectedUnspecified)
 

--- a/context/gsm_handler.go
+++ b/context/gsm_handler.go
@@ -10,6 +10,10 @@ func (smContext *SMContext) HandlePDUSessionEstablishmentRequest(req *nasMessage
 	// Retrieve PDUSessionID
 	smContext.PDUSessionID = int32(req.PDUSessionID.GetPDUSessionID())
 	logger.GsmLog.Infoln("In HandlePDUSessionEstablishmentRequest")
+
+	// Retrieve PTI (Procedure transaction identity)
+	smContext.Pti = req.GetPTI()
+
 	// Handle PDUSessionType
 	if req.PDUSessionType != nil {
 		requestedPDUSessionType := req.PDUSessionType.GetPDUSessionTypeValue()
@@ -114,4 +118,7 @@ func (smContext *SMContext) HandlePDUSessionEstablishmentRequest(req *nasMessage
 
 func (smContext *SMContext) HandlePDUSessionReleaseRequest(req *nasMessage.PDUSessionReleaseRequest) {
 	logger.GsmLog.Infof("Handle Pdu Session Release Request")
+
+	// Retrieve PTI (Procedure transaction identity)
+	smContext.Pti = req.GetPTI()
 }

--- a/context/gsm_handler.go
+++ b/context/gsm_handler.go
@@ -33,7 +33,7 @@ func (smContext *SMContext) HandlePDUSessionEstablishmentRequest(req *nasMessage
 
 		for _, container := range protocolConfigurationOptions.ProtocolOrContainerList {
 			logger.GsmLog.Traceln("Container ID: ", container.ProtocolOrContainerID)
-			logger.GsmLog.Traceln("Container Length: ", container.LengthofContents)
+			logger.GsmLog.Traceln("Container Length: ", container.LengthOfContents)
 			switch container.ProtocolOrContainerID {
 			case nasMessage.PCSCFIPv6AddressRequestUL:
 				logger.GsmLog.Infoln("Didn't Implement container type PCSCFIPv6AddressRequestUL")
@@ -64,7 +64,7 @@ func (smContext *SMContext) HandlePDUSessionEstablishmentRequest(req *nasMessage
 			case nasMessage.IFOMSupportRequestUL:
 				logger.GsmLog.Infoln("Didn't Implement container type IFOMSupportRequestUL")
 			case nasMessage.IPv4LinkMTURequestUL:
-				logger.GsmLog.Infoln("Didn't Implenment container type IPv4LinkMTURequestUL")
+				smContext.ProtocolConfigurationOptions.IPv4LinkMTURequest = true
 			case nasMessage.MSSupportOfLocalAddressInTFTIndicatorUL:
 				logger.GsmLog.Infoln("Didn't Implement container type MSSupportOfLocalAddressInTFTIndicatorUL")
 			case nasMessage.PCSCFReSelectionSupportUL:
@@ -85,8 +85,26 @@ func (smContext *SMContext) HandlePDUSessionEstablishmentRequest(req *nasMessage
 				logger.GsmLog.Infoln("Didn't Implement container type AdditionalAPNRateControlForExceptionDataSupportIndicatorUL")
 			case nasMessage.PDUSessionIDUL:
 				logger.GsmLog.Infoln("Didn't Implement container type PDUSessionIDUL")
+			case nasMessage.EthernetFramePayloadMTURequestUL:
+				logger.GsmLog.Infoln("Didn't Implement container type EthernetFramePayloadMTURequestUL")
+			case nasMessage.UnstructuredLinkMTURequestUL:
+				logger.GsmLog.Infoln("Didn't Implement container type UnstructuredLinkMTURequestUL")
+			case nasMessage.I5GSMCauseValueUL:
+				logger.GsmLog.Infoln("Didn't Implement container type 5GSMCauseValueUL")
+			case nasMessage.QoSRulesWithTheLengthOfTwoOctetsSupportIndicatorUL:
+				logger.GsmLog.Infoln("Didn't Implement container type QoSRulesWithTheLengthOfTwoOctetsSupportIndicatorUL")
+			case nasMessage.QoSFlowDescriptionsWithTheLengthOfTwoOctetsSupportIndicatorUL:
+				logger.GsmLog.Infoln("Didn't Implement container type QoSFlowDescriptionsWithTheLengthOfTwoOctetsSupportIndicatorUL")
+			case nasMessage.LinkControlProtocolUL:
+				logger.GsmLog.Infoln("Didn't Implement container type LinkControlProtocolUL")
+			case nasMessage.PushAccessControlProtocolUL:
+				logger.GsmLog.Infoln("Didn't Implement container type PushAccessControlProtocolUL")
+			case nasMessage.ChallengeHandshakeAuthenticationProtocolUL:
+				logger.GsmLog.Infoln("Didn't Implement container type ChallengeHandshakeAuthenticationProtocolUL")
+			case nasMessage.InternetProtocolControlProtocolUL:
+				logger.GsmLog.Infoln("Didn't Implement container type InternetProtocolControlProtocolUL")
 			default:
-				logger.GsmLog.Infoln("Unknown Container ID [%d]", container.ProtocolOrContainerID)
+				logger.GsmLog.Infof("Unknown Container ID [%d]\n", container.ProtocolOrContainerID)
 			}
 		}
 	}

--- a/context/pco.go
+++ b/context/pco.go
@@ -4,4 +4,5 @@ package context
 type ProtocolConfigurationOptions struct {
 	DNSIPv4Request bool
 	DNSIPv6Request bool
+	IPv4LinkMTURequest bool
 }

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -53,6 +53,7 @@ type SMContext struct {
 	// SUPI or PEI
 	Supi           string
 	Pei            string
+	Pti            uint8
 	Identifier     string
 	Gpsi           string
 	PDUSessionID   int32


### PR DESCRIPTION
Hi team,

This PR supports more IEs which are originally unknown in the PDU session establishment request handler, and add the corresponding parameters requested by the UE. In addition, the PTI field value of the PDU session estab. req. and accept should be the same, this is important to the (some) UE to recognize the estab. accept message.

Note: this PR should be MERGE ALONG WITH [PR#3 in nas library](https://github.com/free5gc/nas/pull/3) in order to make it compilable.

Best,
Chi
