### PR TITLE
Fix UPF nodeID parsing issue when using FQDN

### DIFF
--- a/context/user_plane_information.go
+++ b/context/user_plane_information.go
@@ -71,6 +71,14 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 			//so we can't use the length of return ip to seperate IPv4 and IPv6
 			//This is just a work around
 			var ip net.IP
+
+			//If nodeID is an FQDN, ParseIp() will not work. We need to try DNS
+			//resolution before attempting to parse the IP.
+			resolvedIP, err := net.ResolveIPAddr("ip", node.NodeID)
+			if err == nil {
+				node.NodeID = resolvedIP.String()
+			}
+
 			if net.ParseIP(node.NodeID).To4() == nil {
 				ip = net.ParseIP(node.NodeID)
 			} else {


### PR DESCRIPTION
Hello @free5gc-org,

When an FQDN is used as UPF `node_id` in SMF configuration, IP parsing fails and PFCP session is not established between SMF and UPF. To resolve this issue, and since there is no native way to check whether `node_id` is IPv4, IPv6 or an FQDN, we need to try a name resolution before parsing the IP.

This issue was experienced in the docker version of free5gc: https://github.com/free5gc/free5gc-compose/issues/9. This also provides a fix to issue https://github.com/free5gc/free5gc/issues/111. 

Thanks to @hhoai we now know the root cause of the problem and the solution. The verification step will make sure that the nodeID is updated only when the DNS resolution succeeds.

Cheers,