### PR TITLE
add handle heartbeat request

### DIFF
--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -14,7 +14,8 @@ import (
 )
 
 func HandlePfcpHeartbeatRequest(msg *pfcpUdp.Message) {
-	logger.PfcpLog.Warnf("PFCP Heartbeat Request handling is not implemented")
+	h := msg.PfcpMessage.Header
+	pfcp_message.SendHeartbeatResponse(msg.RemoteAddr, h.SequenceNumber)
 }
 
 func HandlePfcpHeartbeatResponse(msg *pfcpUdp.Message) {

--- a/pfcp/message/send.go
+++ b/pfcp/message/send.go
@@ -315,3 +315,23 @@ func SendPfcpSessionReportResponse(addr *net.UDPAddr, cause pfcpType.Cause, seqF
 
 	udp.SendPfcp(message, addr)
 }
+
+func SendHeartbeatResponse(addr *net.UDPAddr, seq uint32) {
+	pfcpMsg := pfcp.HeartbeatResponse{
+		RecoveryTimeStamp:  &pfcpType.RecoveryTimeStamp{udp.ServerStartTime},
+	}
+
+	message := pfcp.Message{
+		Header: pfcp.Header{
+			Version:        pfcp.PfcpVersion,
+			MP:             0,
+			S:              pfcp.SEID_NOT_PRESENT,
+			MessageType:    pfcp.PFCP_HEARTBEAT_RESPONSE,
+			SequenceNumber: seq,
+		},
+		Body: pfcpMsg,
+	}
+
+	udp.SendPfcp(message, addr)
+}
+


### PR DESCRIPTION
After succeed to associate with UPF, UPF will send heartbeat request to smf, smf receive and send heartbeat reponse to UPF. If UPF can't receive heartbeat response, it will release association.

So SMF should handle heartbeat request and send heartbeat response to UPF.