### PR TITLE
added P-CSCF IPv4 support for smf (needed for ims dnn)

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -163,6 +163,10 @@ func InitSmfContext(config *factory.Config) {
 			dnnInfo := SnssaiSmfDnnInfo{}
 			dnnInfo.DNS.IPv4Addr = net.ParseIP(dnnInfoConfig.DNS.IPv4Addr).To4()
 			dnnInfo.DNS.IPv6Addr = net.ParseIP(dnnInfoConfig.DNS.IPv6Addr).To4()
+			if dnnInfoConfig.PCSCFIPv4Address != "" {
+				pCSCFIPv4Address := net.ParseIP(dnnInfoConfig.PCSCFIPv4Address).To4()
+				dnnInfo.PCSCFIPv4Address = &pCSCFIPv4Address
+			}
 			if allocator, err := NewIPAllocator(dnnInfoConfig.UESubnet); err != nil {
 				logger.InitLog.Errorf("create ip allocator[%s] failed: %s", dnnInfoConfig.UESubnet, err)
 				continue

--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -116,6 +116,11 @@ func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error)
 			}
 		}
 
+		// IPv4 PCSCF IP, needed for ims DNNs
+		if smContext.DNNInfo.PCSCFIPv4Address != nil {
+			protocolConfigurationOptions.AddPCSCFIPv4Address(*smContext.DNNInfo.PCSCFIPv4Address) //
+		}
+
 		// MTU
 		if smContext.ProtocolConfigurationOptions.IPv4LinkMTURequest {
 			err := protocolConfigurationOptions.AddIPv4LinkMTU(1400)

--- a/context/snssai_dnn_smf_info.go
+++ b/context/snssai_dnn_smf_info.go
@@ -10,8 +10,9 @@ type SnssaiSmfInfo struct {
 
 // SnssaiSmfDnnInfo records the SMF per S-NSSAI DNN information
 type SnssaiSmfDnnInfo struct {
-	DNS           DNS
-	UeIPAllocator *IPAllocator
+	DNS              DNS
+	UeIPAllocator    *IPAllocator
+	PCSCFIPv4Address *net.IP
 }
 
 type DNS struct {

--- a/factory/config.go
+++ b/factory/config.go
@@ -50,9 +50,10 @@ type SnssaiInfoItem struct {
 }
 
 type SnssaiDnnInfoItem struct {
-	Dnn      string `yaml:"dnn"`
-	DNS      DNS    `yaml:"dns"`
-	UESubnet string `yaml:"ueSubnet"`
+	Dnn              string `yaml:"dnn"`
+	DNS              DNS    `yaml:"dns"`
+	UESubnet         string `yaml:"ueSubnet"`
+	PCSCFIPv4Address string `yaml:"pcscfIpv4,omitempty"`
 }
 
 type Sbi struct {


### PR DESCRIPTION
By that, the smf tells the UE where the IMS server can be found. This is needed in case of two DNNs, i.e. internet and ims,  in order to work with real UEs.

The syntax in the config file is as follows and optional:

![image](https://user-images.githubusercontent.com/16240312/108885086-a92bca00-7607-11eb-83e4-1aee4a1a8184.png)

The header will only be added to the session establishment accept message if it is specified in the config file. If not, the behavior is as before.
