### PR TITLE
Add: multiple UPF support for v3.0.5

### DIFF
--- a/context/datapath.go
+++ b/context/datapath.go
@@ -568,3 +568,24 @@ func (dataPath *DataPath) DeactivateTunnelAndPDR(smContext *SMContext) {
 
 	dataPath.Activated = false
 }
+
+func (dataPath *DataPath) CopyFirstDPNode() *DataPathNode {
+	if dataPath.FirstDPNode == nil {
+		return nil
+	}
+	var firstNode *DataPathNode = nil
+	var parentNode *DataPathNode = nil
+	for curDataPathNode := dataPath.FirstDPNode; curDataPathNode != nil; curDataPathNode = curDataPathNode.Next() {
+		newNode := NewDataPathNode()
+		if firstNode == nil {
+			firstNode = newNode
+		}
+		newNode.UPF = curDataPathNode.UPF
+		if parentNode != nil {
+			newNode.AddPrev(parentNode)
+			parentNode.AddNext(newNode)
+		}
+		parentNode = newNode
+	}
+	return firstNode
+}

--- a/context/gsm_handler.go
+++ b/context/gsm_handler.go
@@ -135,10 +135,4 @@ func (smContext *SMContext) HandlePDUSessionReleaseRequest(req *nasMessage.PDUSe
 
 	// Retrieve PTI (Procedure transaction identity)
 	smContext.Pti = req.GetPTI()
-
-	if ip := smContext.PDUAddress; ip != nil {
-		logger.PduSessLog.Infof("UE[%s] PDUSessionID[%d] Release IP[%s]",
-			smContext.Supi, smContext.PDUSessionID, smContext.PDUAddress.String())
-		smContext.DNNInfo.UeIPAllocator.Release(ip)
-	}
 }

--- a/context/pool/lazyReusePool.go
+++ b/context/pool/lazyReusePool.go
@@ -1,0 +1,189 @@
+package pool
+
+import (
+	"fmt"
+	"sync"
+)
+
+type LazyReusePool struct {
+	mtx    sync.Mutex
+	head   *segment // nil when empty
+	first  int
+	last   int
+	remain int
+}
+
+type segment struct {
+	first int
+	last  int
+	next  *segment // nil when this segment is tail
+}
+
+type relativePos = int
+
+const (
+	withinThisSegment relativePos = iota
+	adjacentToTheFront
+	adjacentToTheBack
+	before
+	after
+)
+
+// NewLazyReusePool makes a LazyReusePool.
+func NewLazyReusePool(first, last int) (*LazyReusePool, error) {
+	if first > last {
+		return nil, fmt.Errorf("make sure first(%d) <= last(%d)", first, last)
+	}
+	head := &segment{first, last, nil}
+	return &LazyReusePool{
+		head:   head,
+		first:  first,
+		last:   last,
+		remain: last - first + 1,
+	}, nil
+}
+
+func (p *LazyReusePool) Allocate() (res int, ok bool) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if p.head == nil {
+		return 0, false
+	}
+	res = p.head.first
+	p.head.first++
+	if p.head.first > p.head.last {
+		p.head = p.head.next
+	}
+	p.remain--
+	return res, true
+}
+
+func (p *LazyReusePool) Free(value int) bool {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	// Ensure the value is within this pool
+	if value < p.first || p.last < value {
+		return false
+	}
+
+	// When this pool is empty
+	if p.head == nil {
+		p.head = newSingleSegment(value)
+		p.remain++
+		return true
+	}
+
+	// The value is returned into a segment after the head
+	// for lazy reuse, excepted in the case of the value is
+	// adjacent to the back of the head.
+
+	switch p.head.relativePosisionOf(value) {
+	case withinThisSegment:
+		// duplecated free
+		return false
+	case adjacentToTheBack:
+		// only in this case, returned into the head segment
+		p.head.extendLast()
+		p.remain++
+		return true
+	}
+
+	// When there is only head segment
+	if p.head.next == nil {
+		// add a new segment
+		p.head.next = newSingleSegment(value)
+		p.remain++
+		return true
+	}
+
+	prev := p.head
+	cur := p.head.next
+	for ; cur != nil; prev, cur = cur, cur.next {
+		pos := cur.relativePosisionOf(value)
+		switch pos {
+		case before:
+			// insert a segment
+			temp := newSingleSegment(value)
+			prev.next = temp
+			temp.next = cur
+			goto success
+		case adjacentToTheFront:
+			// extendFirst
+			cur.first = value
+			goto success
+		case withinThisSegment:
+			// duplecated free
+			return false
+		case adjacentToTheBack:
+			cur.extendLast()
+			goto success
+		case after:
+			if cur.next == nil {
+				cur.next = newSingleSegment(value)
+				goto success
+			}
+			// to next loop
+		}
+	}
+
+success:
+	p.remain++
+	return true
+}
+
+func (p *LazyReusePool) Remain() int {
+	return p.remain
+}
+
+func (p *LazyReusePool) Total() int {
+	return p.last - p.first + 1
+}
+
+func newSingleSegment(num int) *segment {
+	return &segment{num, num, nil}
+}
+
+func (s *segment) relativePosisionOf(value int) relativePos {
+	switch {
+	case value < s.first-1:
+		return before
+	case value == s.first-1:
+		return adjacentToTheFront
+	case s.first <= value && value <= s.last:
+		return withinThisSegment
+	case value == s.last+1:
+		return adjacentToTheBack
+	default:
+		return after
+	}
+}
+
+func (s *segment) extendLast() *segment {
+	s.last++
+	if s.next != nil && s.last+1 == s.next.first {
+		// concatenate
+		s.last = s.next.last
+		s.next = s.next.next
+	}
+	return s
+}
+
+func (p1 *LazyReusePool) IsJoint(p2 *LazyReusePool) bool {
+	if p2.last < p1.first || p1.last < p2.first {
+		return false
+	}
+	return true
+}
+
+func (p *LazyReusePool) Dump() [][]int {
+	var dumpedSegList [][]int
+	curSeg := p.head
+	for curSeg != nil {
+		dumpedSeg := []int{curSeg.first, curSeg.last}
+		dumpedSegList = append(dumpedSegList, dumpedSeg)
+		curSeg = curSeg.next
+	}
+	return dumpedSegList
+}

--- a/context/pool/lazyReusePool_test.go
+++ b/context/pool/lazyReusePool_test.go
@@ -1,0 +1,219 @@
+package pool
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLazyReusePool(t *testing.T) {
+	// OK : first < last
+	lrp, err := NewLazyReusePool(10, 100)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, lrp)
+	assert.Equal(t, 91, lrp.Total())
+	assert.Equal(t, 91, lrp.Remain())
+
+	// OK : first == last
+	lrp, err = NewLazyReusePool(100, 100)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, lrp)
+	assert.Equal(t, 1, lrp.Total())
+	assert.Equal(t, 1, lrp.Remain())
+
+	// NG : first > last
+	lrp, err = NewLazyReusePool(10, 0)
+	assert.Empty(t, lrp)
+	assert.Error(t, err)
+}
+
+func TestLazyReusePool_SingleSegment(t *testing.T) {
+	// Allocation OK
+	p, _ := NewLazyReusePool(1, 2)
+	a, ok := p.Allocate()
+	assert.Equal(t, 1, a)
+	assert.True(t, ok)
+	assert.Equal(t, 1, p.Remain())
+	a, ok = p.Allocate()
+	assert.Equal(t, a, 2)
+	assert.True(t, ok)
+	assert.Equal(t, 0, p.Remain())
+
+	// exhauted
+	_, ok = p.Allocate()
+	assert.False(t, ok)
+	assert.Equal(t, 0, p.Remain())
+
+	// free 1
+	ok = p.Free(1)
+	assert.Equal(t, 1, p.head.first)
+	assert.Equal(t, 1, p.head.last)
+	assert.Empty(t, p.head.next)
+	assert.Equal(t, 1, p.Remain())
+
+	// out of range
+	ok = p.Free(0)
+	assert.False(t, ok)
+
+	// duplecated free
+	ok = p.Free(1)
+	assert.False(t, ok)
+
+	// free 2
+	ok = p.Free(2)
+	assert.True(t, ok)
+	assert.Equal(t, 2, p.Remain())
+
+	// reuse
+	a, ok = p.Allocate()
+	assert.Equal(t, 1, a)
+	assert.True(t, ok)
+	assert.Equal(t, 1, p.Remain())
+	assert.Equal(t, 2, p.Total())
+}
+
+func TestLazyReusePool_ManySegment(t *testing.T) {
+	p, _ := NewLazyReusePool(1, 100)
+	assert.Equal(t, 100, p.Remain())
+
+	// -> 1-100
+
+	for i := 0; i < 99; i++ {
+		_, ok := p.Allocate()
+		assert.True(t, ok)
+	}
+
+	// -> 100-100
+	assert.Equal(t, 1, p.Remain())
+
+	p.Free(3) // -> 100-100 -> 3-3
+	p.Free(6) // -> 100-100 -> 3-3 -> 6-6
+
+	assert.Equal(t, 3, p.head.next.first)
+	assert.Equal(t, 3, p.head.next.last)
+	assert.Equal(t, 6, p.head.next.next.first)
+	assert.Equal(t, 6, p.head.next.next.last)
+	assert.Equal(t, 3, p.Remain())
+
+	// adjacent to the front
+	p.Free(2) // -> 100-100 -> 2-3 -> 6-6
+	assert.Equal(t, 2, p.head.next.first)
+	assert.Equal(t, 3, p.head.next.last)
+	assert.Equal(t, 4, p.Remain())
+
+	// duplicate
+	ok := p.Free(3)
+	assert.False(t, ok)
+
+	// adjacent to the back
+	p.Free(4) // -> 100-100 -> 2-4 -> 6-6
+	assert.Equal(t, 2, p.head.next.first)
+	assert.Equal(t, 4, p.head.next.last)
+	assert.Equal(t, 5, p.Remain())
+
+	// 3rd segment
+	p.Free(7) // -> 100-100 -> 2-4 -> 6-7
+	assert.Equal(t, 6, p.head.next.next.first)
+	assert.Equal(t, 7, p.head.next.next.last)
+	assert.Equal(t, 6, p.Remain())
+
+	// concatenate
+	p.Free(5) // -> 100-100 -> 2-7
+	assert.Equal(t, 2, p.head.next.first)
+	assert.Equal(t, 7, p.head.next.last)
+	assert.Empty(t, p.head.next.next)
+	assert.Equal(t, 7, p.Remain())
+
+	// new head
+	a, ok := p.Allocate() // -> 2-7
+	assert.Equal(t, a, 100)
+	assert.True(t, ok)
+	assert.Equal(t, 2, p.head.first)
+	assert.Equal(t, 7, p.head.last)
+	assert.Equal(t, 6, p.Remain())
+
+	// reuse
+	a, ok = p.Allocate() // -> 3-7
+	assert.Equal(t, a, 2)
+	assert.True(t, ok)
+	assert.Equal(t, 3, p.head.first)
+	assert.Equal(t, 7, p.head.last)
+	assert.Empty(t, p.head.next)
+	assert.Equal(t, 5, p.Remain())
+
+	// return to head
+	p.Free(100) // -> 3-7 -> 100-100
+	p.Free(8)   // -> 3-8 -> 100-100
+	assert.Equal(t, 3, p.head.first)
+	assert.Equal(t, 8, p.head.last)
+	assert.Equal(t, 100, p.head.next.first)
+	assert.Equal(t, 100, p.head.next.last)
+	assert.Equal(t, 7, p.Remain())
+
+	// return into between head and 2nd
+	p.Free(10) // -> 3-8 -> 10-10 -> 100-100
+	assert.Equal(t, 3, p.head.first)
+	assert.Equal(t, 8, p.head.last)
+	assert.Equal(t, 10, p.head.next.first)
+	assert.Equal(t, 10, p.head.next.last)
+	assert.Equal(t, 100, p.head.next.next.first)
+	assert.Equal(t, 100, p.head.next.next.last)
+	assert.Equal(t, 8, p.Remain())
+
+	// concatenate head and 2nd
+	p.Free(9) // -> 3-10 -> 100-100
+	assert.Equal(t, 3, p.head.first)
+	assert.Equal(t, 10, p.head.last)
+	assert.Equal(t, 100, p.head.next.first)
+	assert.Equal(t, 100, p.head.next.last)
+	assert.Empty(t, p.head.next.next)
+	assert.Equal(t, 9, p.Remain())
+}
+
+func TestLazyReusePool_ManyGoroutine(t *testing.T) {
+	p, _ := NewLazyReusePool(101, 1000)
+	assert.Equal(t, 900, p.Remain())
+	ch := make(chan int)
+
+	numOfThreads := 400
+
+	for i := 0; i < numOfThreads; i++ {
+		// Allocate 2 times and Free 1 time
+		go func() {
+			a1, ok := p.Allocate()
+			assert.True(t, ok)
+			ch <- a1
+
+			time.Sleep(10 * time.Millisecond)
+
+			ok = p.Free(a1)
+			assert.True(t, ok)
+
+			time.Sleep(10 * time.Millisecond)
+
+			a2, ok := p.Allocate()
+			assert.True(t, ok)
+			ch <- a2
+		}()
+	}
+	// collect allocated values
+	allocated := make([]int, 0, numOfThreads*2)
+	for i := 0; i < numOfThreads*2; i++ {
+		allocated = append(allocated, <-ch)
+	}
+	sort.Ints(allocated)
+
+	expected := make([]int, numOfThreads*2)
+	for i := 0; i < numOfThreads*2; i++ {
+		expected[i] = p.first + i
+	}
+	assert.Equal(t, expected, allocated)
+	assert.Equal(t, 900-numOfThreads, p.Remain())
+
+	a, ok := p.Allocate()
+	assert.Equal(t, p.first+numOfThreads*2, a)
+	assert.True(t, ok)
+	assert.Equal(t, 900-numOfThreads-1, p.Remain())
+}

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -93,8 +93,9 @@ type SMContext struct {
 
 	SMContextState SMContextState
 
-	Tunnel    *UPTunnel
-	BPManager *BPManager
+	Tunnel      *UPTunnel
+	SelectedUPF *UPNode
+	BPManager   *BPManager
 	// NodeID(string form) to PFCP Session Context
 	PFCPContext                         map[string]*PFCPSessionContext
 	SBIPFCPCommunicationChan            chan PFCPSessionResponseStatus
@@ -176,6 +177,12 @@ func RemoveSMContext(ref string) {
 	var smContext *SMContext
 	if value, ok := smContextPool.Load(ref); ok {
 		smContext = value.(*SMContext)
+	}
+
+	if smContext.SelectedUPF != nil {
+		logger.PduSessLog.Infof("UE[%s] PDUSessionID[%d] Release IP[%s]",
+			smContext.Supi, smContext.PDUSessionID, smContext.PDUAddress.String())
+		GetUserPlaneInformation().ReleaseUEIP(smContext.SelectedUPF, smContext.PDUAddress)
 	}
 
 	for _, pfcpSessionContext := range smContext.PFCPContext {

--- a/context/snssai.go
+++ b/context/snssai.go
@@ -1,6 +1,11 @@
 package context
 
-import "github.com/free5gc/openapi/models"
+import (
+	"net"
+
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/smf/context/pool"
+)
 
 type SNssai struct {
 	Sst int32
@@ -22,6 +27,13 @@ type DnnUPFInfoItem struct {
 	Dnn             string
 	DnaiList        []string
 	PduSessionTypes []models.PduSessionType
+	UeIPPools       []*UeIPPool
+}
+
+// UeIPPool represent IP address pool for UE
+type UeIPPool struct {
+	ueSubNet *net.IPNet
+	pool     *pool.LazyReusePool
 }
 
 // ContainsDNAI return true if the this dnn Info contains the specify DNAI

--- a/context/snssai_dnn_smf_info.go
+++ b/context/snssai_dnn_smf_info.go
@@ -10,8 +10,7 @@ type SnssaiSmfInfo struct {
 
 // SnssaiSmfDnnInfo records the SMF per S-NSSAI DNN information
 type SnssaiSmfDnnInfo struct {
-	DNS           DNS
-	UeIPAllocator *IPAllocator
+	DNS DNS
 }
 
 type DNS struct {

--- a/context/ue_defaultPath.go
+++ b/context/ue_defaultPath.go
@@ -1,0 +1,221 @@
+package context
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"sort"
+
+	"github.com/free5gc/smf/factory"
+	"github.com/free5gc/smf/logger"
+)
+
+type UEDefaultPaths struct {
+	AnchorUPFs      []string // list of UPF name
+	DefaultPathPool DefaultPathPool
+}
+
+type DefaultPathPool map[string]*DataPath // key: UPF name
+
+func NewUEDefaultPaths(upi *UserPlaneInformation, topology []factory.UPLink) (*UEDefaultPaths, error) {
+	defaultPathPool := make(map[string]*DataPath)
+	source, err := findSourceInTopology(upi, topology)
+	if err != nil {
+		return nil, err
+	}
+	destinations, err := extractAnchorUPFForULCL(upi, source, topology)
+	if err != nil {
+		return nil, err
+	}
+	for _, destination := range destinations {
+		path, err := generateDefaultDataPath(source, destination, topology)
+		if err != nil {
+			return nil, err
+		}
+		defaultPathPool[destination] = path
+	}
+	defautlPaths := &UEDefaultPaths{
+		AnchorUPFs:      destinations,
+		DefaultPathPool: defaultPathPool,
+	}
+	return defautlPaths, nil
+}
+
+func findSourceInTopology(upi *UserPlaneInformation, topology []factory.UPLink) (string, error) {
+	sourceList := make([]string, 0)
+	for key, node := range upi.AccessNetwork {
+		if node.Type == UPNODE_AN {
+			sourceList = append(sourceList, key)
+		}
+	}
+	for _, anName := range sourceList {
+		for _, link := range topology {
+			if link.A == anName || link.B == anName {
+				// if multiple gNBs exist, select one according to some criterion
+				logger.InitLog.Debugf("%s is AN", anName)
+				return anName, nil
+			}
+		}
+	}
+	return "", errors.New("Not found AN node in topology")
+}
+
+func extractAnchorUPFForULCL(upi *UserPlaneInformation, source string, topology []factory.UPLink) ([]string, error) {
+	upList := make([]string, 0)
+	visited := make(map[string]bool)
+	queue := make([]string, 0)
+
+	queue = append(queue, source)
+	queued := make(map[string]bool)
+	queued[source] = true
+
+	for {
+		node := queue[0]
+		queue = queue[1:]
+		findNewLink := false
+		for _, link := range topology {
+			if link.A == node {
+				if !queued[link.B] {
+					queue = append(queue, link.B)
+					queued[link.B] = true
+					findNewLink = true
+				}
+				if !visited[link.B] {
+					findNewLink = true
+				}
+			}
+			if link.B == node {
+				if !queued[link.A] {
+					queue = append(queue, link.A)
+					queued[link.A] = true
+					findNewLink = true
+				}
+				if !visited[link.A] {
+					findNewLink = true
+				}
+			}
+		}
+		visited[node] = true
+		if !findNewLink {
+			logger.InitLog.Debugf("%s is Anchor UPF", node)
+			upList = append(upList, node)
+		}
+		if len(queue) == 0 {
+			break
+		}
+	}
+	if len(upList) == 0 {
+		return nil, errors.New("Not found Anchor UPF in topology")
+	}
+	sort.Strings(upList)
+	return upList, nil
+}
+
+func generateDefaultDataPath(source string, destination string, topology []factory.UPLink) (*DataPath, error) {
+	visited := make(map[string]bool)
+	currentPath := []string{}
+	allPaths := make(map[int][]string)
+	count := 0
+	getPathBetweenByNodeName(source, destination, topology, visited, currentPath, allPaths, &count)
+	if len(allPaths) == 0 {
+		return nil, fmt.Errorf("Path not exist: %s to %s", source, destination)
+	}
+
+	dataPath := NewDataPath()
+	lowerBound := 0
+	var parentNode *DataPathNode = nil
+
+	// if multiple Paths exist, select one according to some criterion
+	for idx, nodeName := range allPaths[0] {
+		newUeNode, err := NewUEDataPathNode(nodeName)
+		if err != nil {
+			return nil, err
+		}
+		if idx == lowerBound {
+			dataPath.FirstDPNode = newUeNode
+		}
+		if parentNode != nil {
+			newUeNode.AddPrev(parentNode)
+			parentNode.AddNext(newUeNode)
+		}
+		parentNode = newUeNode
+	}
+	logger.CtxLog.Tracef("New default data path (%s to %s): ", source, destination)
+	logger.CtxLog.Traceln("\n" + dataPath.String() + "\n")
+	return dataPath, nil
+}
+
+func getPathBetweenByNodeName(src string, dest string, links []factory.UPLink, visited map[string]bool,
+	currentPath []string, allPaths map[int][]string, count *int) {
+	if visited[src] {
+		return
+	}
+	visited[src] = true
+	currentPath = append(currentPath, src)
+	logger.InitLog.Traceln("current path:", currentPath)
+	if src == dest {
+		allPaths[*count] = currentPath[1:]
+		(*count)++
+		logger.InitLog.Traceln("all path:", allPaths)
+		visited[src] = false
+		currentPath = []string{}
+		return
+	}
+	for _, link := range links {
+		// search A to B only
+		if link.A == src {
+			getPathBetweenByNodeName(link.B, dest, links, visited, currentPath, allPaths, count)
+		}
+	}
+	visited[src] = false
+	currentPath = []string{}
+}
+
+func createUPFListForSelectionULCL(inputList []string) (outputList []string) {
+	offset := rand.Intn(len(inputList))
+	return append(inputList[offset:], inputList[:offset]...)
+}
+
+func (dfp *UEDefaultPaths) SelectUPFAndAllocUEIPForULCL(upi *UserPlaneInformation, selection *UPFSelectionParams) (string, net.IP) {
+
+	sortedUPFList := createUPFListForSelectionULCL(dfp.AnchorUPFs)
+
+	for _, upfName := range sortedUPFList {
+		logger.CtxLog.Debugf("check start UPF: %s", upfName)
+		upf := upi.UPFs[upfName]
+
+		pools := getUEIPPool(upf, selection)
+		if pools == nil || len(pools) == 0 {
+			continue
+		}
+		sortedPoolList := createPoolListForSelection(pools)
+		for _, pool := range sortedPoolList {
+			logger.CtxLog.Debugf("check start UEIPPool(%+v)", pool.ueSubNet)
+			addr := pool.allocate()
+			if addr != nil {
+				logger.CtxLog.Infof("Selected UPF: %s", upfName)
+				return upfName, addr
+			}
+			// if all addresses in pool are used, search next pool
+			logger.CtxLog.Debug("check next pool")
+		}
+		// if all addresses in UPF are used, search next UPF
+		logger.CtxLog.Debug("check next upf")
+	}
+	// checked all UPFs
+	logger.CtxLog.Warnf("UE IP pool exhausted for DNN[%s] S-NSSAI[sst: %d sd: %s] DNAI[%s]\n", selection.Dnn,
+		selection.SNssai.Sst, selection.SNssai.Sd, selection.Dnai)
+	return "", nil
+}
+
+func (dfp *UEDefaultPaths) GetDefaultPath(upfName string) *DataPath {
+	firstNode := dfp.DefaultPathPool[upfName].CopyFirstDPNode()
+	dataPath := &DataPath{
+		Activated:     false,
+		IsDefaultPath: true,
+		Destination:   dfp.DefaultPathPool[upfName].Destination,
+		FirstDPNode:   firstNode,
+	}
+	return dataPath
+}

--- a/context/ulcl_group.go
+++ b/context/ulcl_group.go
@@ -1,0 +1,13 @@
+package context
+
+func GetULCLGroupNameFromSUPI(SUPI string) string {
+	ulclGroups := smfContext.ULCLGroups
+	for name, group := range ulclGroups {
+		for _, member := range group {
+			if member == SUPI {
+				return name
+			}
+		}
+	}
+	return ""
+}

--- a/context/user_plane_information.go
+++ b/context/user_plane_information.go
@@ -1,23 +1,31 @@
 package context
 
 import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
 	"net"
 	"reflect"
+	"sort"
 
 	"github.com/free5gc/pfcp/pfcpType"
+	"github.com/free5gc/smf/context/pool"
 	"github.com/free5gc/smf/factory"
 	"github.com/free5gc/smf/logger"
 )
 
 // UserPlaneInformation store userplane topology
 type UserPlaneInformation struct {
-	UPNodes              map[string]*UPNode
-	UPFs                 map[string]*UPNode
-	AccessNetwork        map[string]*UPNode
-	UPFIPToName          map[string]string
-	UPFsID               map[string]string    // name to id
-	UPFsIPtoID           map[string]string    // ip->id table, for speed optimization
-	DefaultUserPlanePath map[string][]*UPNode // DNN to Default Path
+	UPNodes                   map[string]*UPNode
+	UPFs                      map[string]*UPNode
+	AccessNetwork             map[string]*UPNode
+	UPFIPToName               map[string]string
+	UPFsID                    map[string]string               // name to id
+	UPFsIPtoID                map[string]string               // ip->id table, for speed optimization
+	DefaultUserPlanePath      map[string][]*UPNode            // DNN to Default Path
+	DefaultUserPlanePathToUPF map[string]map[string][]*UPNode // DNN and UPF to Default Path
 }
 
 type UPNodeType string
@@ -59,6 +67,7 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 	upfPool := make(map[string]*UPNode)
 	anPool := make(map[string]*UPNode)
 	upfIPMap := make(map[string]string)
+	allUEIPPools := []*UeIPPool{}
 
 	for name, node := range upTopology.UPNodes {
 		upNode := new(UPNode)
@@ -108,10 +117,21 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 				}
 
 				for _, dnnInfoConfig := range snssaiInfoConfig.DnnUpfInfoList {
+					ueIPPools := make([]*UeIPPool, 0)
+					for _, pool := range dnnInfoConfig.Pools {
+						ueIPPool := NewUEIPPool(&pool)
+						if ueIPPool == nil {
+							logger.InitLog.Fatalf("invalid pools value: %+v", pool)
+						} else {
+							ueIPPools = append(ueIPPools, ueIPPool)
+							allUEIPPools = append(allUEIPPools, ueIPPool)
+						}
+					}
 					snssaiInfo.DnnList = append(snssaiInfo.DnnList, DnnUPFInfoItem{
 						Dnn:             dnnInfoConfig.Dnn,
 						DnaiList:        dnnInfoConfig.DnaiList,
 						PduSessionTypes: dnnInfoConfig.PduSessionTypes,
+						UeIPPools:       ueIPPools,
 					})
 				}
 				snssaiInfos = append(snssaiInfos, snssaiInfo)
@@ -128,6 +148,10 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 		upfIPMap[ipStr] = name
 	}
 
+	if isOverlap(allUEIPPools) {
+		logger.InitLog.Fatalf("overlap cidr value between UPFs")
+	}
+
 	for _, link := range upTopology.Links {
 		nodeA := nodePool[link.A]
 		nodeB := nodePool[link.B]
@@ -140,16 +164,72 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 	}
 
 	userplaneInformation := &UserPlaneInformation{
-		UPNodes:              nodePool,
-		UPFs:                 upfPool,
-		AccessNetwork:        anPool,
-		UPFIPToName:          upfIPMap,
-		UPFsID:               make(map[string]string),
-		UPFsIPtoID:           make(map[string]string),
-		DefaultUserPlanePath: make(map[string][]*UPNode),
+		UPNodes:                   nodePool,
+		UPFs:                      upfPool,
+		AccessNetwork:             anPool,
+		UPFIPToName:               upfIPMap,
+		UPFsID:                    make(map[string]string),
+		UPFsIPtoID:                make(map[string]string),
+		DefaultUserPlanePath:      make(map[string][]*UPNode),
+		DefaultUserPlanePathToUPF: make(map[string]map[string][]*UPNode),
 	}
 
 	return userplaneInformation
+}
+
+func NewUEIPPool(factoryPool *factory.UEIPPool) *UeIPPool {
+	_, ipNet, err := net.ParseCIDR(factoryPool.Cidr)
+	if err != nil {
+		logger.InitLog.Errorln(err)
+		return nil
+	}
+
+	minAddr, maxAddr, err := calcAddrRange(ipNet)
+	if err != nil {
+		logger.InitLog.Errorln(err)
+		return nil
+	}
+
+	newPool, err := pool.NewLazyReusePool(int(minAddr), int(maxAddr))
+	if err != nil {
+		logger.InitLog.Errorln(err)
+		return nil
+	}
+
+	ueIPPool := &UeIPPool{
+		ueSubNet: ipNet,
+		pool:     newPool,
+	}
+	return ueIPPool
+}
+
+func calcAddrRange(ipNet *net.IPNet) (minAddr, maxAddr uint32, err error) {
+	maskVal := binary.BigEndian.Uint32(ipNet.Mask)
+	baseIPVal := binary.BigEndian.Uint32(ipNet.IP)
+	if maskVal == math.MaxUint32 {
+		return baseIPVal, baseIPVal, nil
+	}
+	minAddr = (baseIPVal & maskVal) + 1  // 0 is network address
+	maxAddr = (baseIPVal | ^maskVal) - 1 // all 1 is broadcast address
+	if minAddr > maxAddr {
+		return minAddr, maxAddr, errors.New("Mask is invalid.")
+	}
+	return minAddr, maxAddr, nil
+}
+
+func isOverlap(pools []*UeIPPool) bool {
+	if len(pools) < 2 {
+		// no need to check
+		return false
+	}
+	for i := 0; i < len(pools)-1; i++ {
+		for j := i + 1; j < len(pools); j++ {
+			if pools[i].pool.IsJoint(pools[j].pool) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (upi *UserPlaneInformation) GetUPFNameByIp(ip string) string {
@@ -180,6 +260,25 @@ func (upi *UserPlaneInformation) GetDefaultUserPlanePathByDNN(selection *UPFSele
 		if pathExist {
 			return upi.DefaultUserPlanePath[selection.String()]
 		}
+	}
+	return nil
+}
+
+func (upi *UserPlaneInformation) GetDefaultUserPlanePathByDNNAndUPF(selection *UPFSelectionParams, upf *UPNode) (path UPPath) {
+	nodeID := upf.NodeID.ResolveNodeIdToIp().String()
+	var pathExist bool
+
+	if upi.DefaultUserPlanePathToUPF[selection.String()] != nil {
+		path, pathExist := upi.DefaultUserPlanePathToUPF[selection.String()][nodeID]
+		logger.CtxLog.Traceln("In GetDefaultUserPlanePathByDNN")
+		logger.CtxLog.Traceln("selection: ", selection.String())
+		if pathExist {
+			return path
+		}
+	}
+	pathExist = upi.GenerateDefaultPathToUPF(selection, upf)
+	if pathExist {
+		return upi.DefaultUserPlanePathToUPF[selection.String()][nodeID]
 	}
 	return nil
 }
@@ -275,6 +374,43 @@ func (upi *UserPlaneInformation) GenerateDefaultPath(selection *UPFSelectionPara
 	return pathExist
 }
 
+func (upi *UserPlaneInformation) GenerateDefaultPathToUPF(selection *UPFSelectionParams, destination *UPNode) bool {
+	var source *UPNode
+
+	for _, node := range upi.AccessNetwork {
+		if node.Type == UPNODE_AN {
+			source = node
+			break
+		}
+	}
+
+	if source == nil {
+		logger.CtxLog.Errorf("There is no AN Node in config file!")
+		return false
+	}
+
+	// Run DFS
+	visited := make(map[*UPNode]bool)
+
+	for _, upNode := range upi.UPNodes {
+		visited[upNode] = false
+	}
+
+	path, pathExist := getPathBetween(source, destination, visited, selection)
+
+	if pathExist {
+		if path[0].Type == UPNODE_AN {
+			path = path[1:]
+		}
+		if upi.DefaultUserPlanePathToUPF[selection.String()] == nil {
+			upi.DefaultUserPlanePathToUPF[selection.String()] = make(map[string][]*UPNode)
+		}
+		upi.DefaultUserPlanePathToUPF[selection.String()][destination.NodeID.ResolveNodeIdToIp().String()] = path
+	}
+
+	return pathExist
+}
+
 func (upi *UserPlaneInformation) selectMatchUPF(selection *UPFSelectionParams) []*UPNode {
 	upList := make([]*UPNode, 0)
 
@@ -331,4 +467,203 @@ func getPathBetween(cur *UPNode, dest *UPNode, visited map[*UPNode]bool,
 	}
 
 	return nil, false
+}
+
+func (upi *UserPlaneInformation) selectAnchorUPF(source *UPNode, selection *UPFSelectionParams) []*UPNode {
+	upList := make([]*UPNode, 0)
+	visited := make(map[*UPNode]bool)
+	queue := make([]*UPNode, 0)
+	targetSnssai := selection.SNssai
+
+	queue = append(queue, source)
+	for {
+		node := queue[0]
+		queue = queue[1:]
+		findNewNode := false
+		visited[node] = true
+		for _, link := range node.Links {
+			if !visited[link] {
+				for _, snssaiInfo := range link.UPF.SNssaiInfos {
+					currentSnssai := &snssaiInfo.SNssai
+					if currentSnssai.Equal(targetSnssai) {
+						for _, dnnInfo := range snssaiInfo.DnnList {
+							if dnnInfo.Dnn == selection.Dnn && dnnInfo.ContainsDNAI(selection.Dnai) {
+								queue = append(queue, link)
+								findNewNode = true
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+		if !findNewNode {
+			upList = append(upList, node)
+		}
+		if len(queue) == 0 {
+			break
+		}
+	}
+	return upList
+}
+
+func (upi *UserPlaneInformation) sortUPFListByName(upfList []*UPNode) []*UPNode {
+	keys := make([]string, 0, len(upi.UPFs))
+	for k := range upi.UPFs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	sortedUpList := make([]*UPNode, 0)
+	for _, name := range keys {
+		for _, node := range upfList {
+			if name == upi.GetUPFNameByIp(node.NodeID.ResolveNodeIdToIp().String()) {
+				sortedUpList = append(sortedUpList, node)
+			}
+		}
+	}
+	return sortedUpList
+}
+
+func (upi *UserPlaneInformation) selectUPPathSource() (*UPNode, error) {
+	// if multiple gNBs exist, select one according to some criterion
+	for _, node := range upi.AccessNetwork {
+		if node.Type == UPNODE_AN {
+			return node, nil
+		}
+	}
+	return nil, errors.New("AN Node not found")
+}
+
+func (upi *UserPlaneInformation) SelectUPFAndAllocUEIP(selection *UPFSelectionParams) (*UPNode, net.IP) {
+	source, err := upi.selectUPPathSource()
+	if err != nil {
+		return nil, nil
+	}
+	UPFList := upi.selectAnchorUPF(source, selection)
+	listLength := len(UPFList)
+	if listLength == 0 {
+		logger.CtxLog.Warnf("Can't find UPF with DNN[%s] S-NSSAI[sst: %d sd: %s] DNAI[%s]\n", selection.Dnn,
+			selection.SNssai.Sst, selection.SNssai.Sd, selection.Dnai)
+		return nil, nil
+	}
+	UPFList = upi.sortUPFListByName(UPFList)
+	sortedUPFList := createUPFListForSelection(UPFList)
+	for _, upf := range sortedUPFList {
+		logger.CtxLog.Debugf("check start UPF: %s",
+			upi.GetUPFNameByIp(upf.NodeID.ResolveNodeIdToIp().String()))
+		pools := getUEIPPool(upf, selection)
+		if pools == nil || len(pools) == 0 {
+			continue
+		}
+		sortedPoolList := createPoolListForSelection(pools)
+		for _, pool := range sortedPoolList {
+			logger.CtxLog.Debugf("check start UEIPPool(%+v)", pool.ueSubNet)
+			addr := pool.allocate()
+			if addr != nil {
+				logger.CtxLog.Infof("Selected UPF: %s",
+					upi.GetUPFNameByIp(upf.NodeID.ResolveNodeIdToIp().String()))
+				return upf, addr
+			}
+			// if all addresses in pool are used, search next pool
+			logger.CtxLog.Debug("check next pool")
+		}
+		// if all addresses in UPF are used, search next UPF
+		logger.CtxLog.Debug("check next upf")
+	}
+	// checked all UPFs
+	logger.CtxLog.Warnf("UE IP pool exhausted for DNN[%s] S-NSSAI[sst: %d sd: %s] DNAI[%s]\n", selection.Dnn,
+		selection.SNssai.Sst, selection.SNssai.Sd, selection.Dnai)
+	return nil, nil
+}
+
+func createUPFListForSelection(inputList []*UPNode) (outputList []*UPNode) {
+	offset := rand.Intn(len(inputList))
+	return append(inputList[offset:], inputList[:offset]...)
+}
+
+func createPoolListForSelection(inputList []*UeIPPool) (outputList []*UeIPPool) {
+	offset := rand.Intn(len(inputList))
+	return append(inputList[offset:], inputList[:offset]...)
+}
+
+func getUEIPPool(upNode *UPNode, selection *UPFSelectionParams) []*UeIPPool {
+	for _, snssaiInfo := range upNode.UPF.SNssaiInfos {
+		currentSnssai := &snssaiInfo.SNssai
+		targetSnssai := selection.SNssai
+
+		if currentSnssai.Equal(targetSnssai) {
+			for _, dnnInfo := range snssaiInfo.DnnList {
+				if dnnInfo.Dnn == selection.Dnn && dnnInfo.ContainsDNAI(selection.Dnai) {
+					return dnnInfo.UeIPPools
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (ueIPPool *UeIPPool) allocate() net.IP {
+	allocVal, res := ueIPPool.pool.Allocate()
+	if !res {
+		logger.CtxLog.Warnf("Pool is empty: %+v", ueIPPool.ueSubNet)
+		return nil
+	}
+	buf := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf, uint32(allocVal))
+	logger.CtxLog.Infof("Allocated UE IP address: %v", net.IPv4(buf[0], buf[1], buf[2], buf[3]))
+	return buf
+}
+
+func (upi *UserPlaneInformation) ReleaseUEIP(upf *UPNode, addr net.IP) {
+	pool := findPoolByAddr(upf, addr)
+	if pool == nil {
+		//nothing to do
+		logger.CtxLog.Warnf("Fail to release UE IP address: %v to UPF: %s",
+			upi.GetUPFNameByIp(upf.NodeID.ResolveNodeIdToIp().String()), addr)
+		return
+	}
+	pool.release(addr)
+}
+
+func findPoolByAddr(upf *UPNode, addr net.IP) *UeIPPool {
+	for _, snssaiInfo := range upf.UPF.SNssaiInfos {
+		for _, dnnInfo := range snssaiInfo.DnnList {
+			for _, pool := range dnnInfo.UeIPPools {
+				if pool.ueSubNet.Contains(addr) {
+					return pool
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (ueIPPool *UeIPPool) release(addr net.IP) {
+	addrVal := binary.BigEndian.Uint32(addr)
+	res := ueIPPool.pool.Free(int(addrVal))
+	if !res {
+		logger.CtxLog.Warnf("failed to release UE Address: %s", addr)
+	}
+	logger.CtxLog.Debug(ueIPPool.dump())
+}
+
+func (ueIPPool *UeIPPool) dump() string {
+	str := "["
+	elements := ueIPPool.pool.Dump()
+	for index, element := range elements {
+		var firstAddr net.IP
+		var lastAddr net.IP
+		buf := make([]byte, 4)
+		binary.BigEndian.PutUint32(buf, uint32(element[0]))
+		firstAddr = buf
+		buf = make([]byte, 4)
+		binary.BigEndian.PutUint32(buf, uint32(element[1]))
+		lastAddr = buf
+		if index > 0 {
+			str += ("->")
+		}
+		str += fmt.Sprintf("{%s - %s}", firstAddr.String(), lastAddr.String())
+	}
+	str += ("]")
+	return str
 }

--- a/context/user_plane_information_test.go
+++ b/context/user_plane_information_test.go
@@ -19,13 +19,13 @@ var configuration = &factory.UserPlaneInformation{
 		"UPF1": {
 			Type:   "UPF",
 			NodeID: "192.168.179.1",
-			SNssaiInfos: []models.SnssaiUpfInfoItem{
+			SNssaiInfos: []factory.SnssaiUpfInfoItem{
 				{
 					SNssai: &models.Snssai{
 						Sst: 1,
 						Sd:  "112232",
 					},
-					DnnUpfInfoList: []models.DnnUpfInfoItem{
+					DnnUpfInfoList: []factory.DnnUpfInfoItem{
 						{Dnn: "internet"},
 					},
 				},
@@ -34,7 +34,7 @@ var configuration = &factory.UserPlaneInformation{
 						Sst: 1,
 						Sd:  "112235",
 					},
-					DnnUpfInfoList: []models.DnnUpfInfoItem{
+					DnnUpfInfoList: []factory.DnnUpfInfoItem{
 						{Dnn: "internet"},
 					},
 				},
@@ -43,13 +43,13 @@ var configuration = &factory.UserPlaneInformation{
 		"UPF2": {
 			Type:   "UPF",
 			NodeID: "192.168.179.2",
-			SNssaiInfos: []models.SnssaiUpfInfoItem{
+			SNssaiInfos: []factory.SnssaiUpfInfoItem{
 				{
 					SNssai: &models.Snssai{
 						Sst: 2,
 						Sd:  "112233",
 					},
-					DnnUpfInfoList: []models.DnnUpfInfoItem{
+					DnnUpfInfoList: []factory.DnnUpfInfoItem{
 						{Dnn: "internet"},
 					},
 				},
@@ -58,13 +58,13 @@ var configuration = &factory.UserPlaneInformation{
 		"UPF3": {
 			Type:   "UPF",
 			NodeID: "192.168.179.3",
-			SNssaiInfos: []models.SnssaiUpfInfoItem{
+			SNssaiInfos: []factory.SnssaiUpfInfoItem{
 				{
 					SNssai: &models.Snssai{
 						Sst: 3,
 						Sd:  "112234",
 					},
-					DnnUpfInfoList: []models.DnnUpfInfoItem{
+					DnnUpfInfoList: []factory.DnnUpfInfoItem{
 						{Dnn: "internet"},
 					},
 				},
@@ -73,13 +73,13 @@ var configuration = &factory.UserPlaneInformation{
 		"UPF4": {
 			Type:   "UPF",
 			NodeID: "192.168.179.4",
-			SNssaiInfos: []models.SnssaiUpfInfoItem{
+			SNssaiInfos: []factory.SnssaiUpfInfoItem{
 				{
 					SNssai: &models.Snssai{
 						Sst: 1,
 						Sd:  "112235",
 					},
-					DnnUpfInfoList: []models.DnnUpfInfoItem{
+					DnnUpfInfoList: []factory.DnnUpfInfoItem{
 						{Dnn: "internet"},
 					},
 				},

--- a/factory/config.go
+++ b/factory/config.go
@@ -50,9 +50,8 @@ type SnssaiInfoItem struct {
 }
 
 type SnssaiDnnInfoItem struct {
-	Dnn      string `yaml:"dnn"`
-	DNS      DNS    `yaml:"dns"`
-	UESubnet string `yaml:"ueSubnet"`
+	Dnn string `yaml:"dnn"`
+	DNS DNS    `yaml:"dns"`
 }
 
 type Sbi struct {
@@ -86,9 +85,10 @@ type Path struct {
 }
 
 type UERoutingInfo struct {
-	SUPI     string `yaml:"SUPI,omitempty"`
-	AN       string `yaml:"AN,omitempty"`
-	PathList []Path `yaml:"PathList,omitempty"`
+	Members       []string       `yaml:"members"`
+	AN            string         `yaml:"AN,omitempty"`
+	Topology      []UPLink       `yaml:"topology"`
+	SpecificPaths []SpecificPath `yaml:"specificPath,omitempty"`
 }
 
 // RouteProfID is string providing a Route Profile identifier.
@@ -127,7 +127,7 @@ type PfdDataForApp struct {
 
 type RoutingConfig struct {
 	Info          *Info                        `yaml:"info"`
-	UERoutingInfo []*UERoutingInfo             `yaml:"ueRoutingInfo"`
+	UERoutingInfo map[string]UERoutingInfo     `yaml:"ueRoutingInfo"`
 	RouteProf     map[RouteProfID]RouteProfile `yaml:"routeProfile,omitempty"`
 	PfdDatas      []*PfdDataForApp             `yaml:"pfdDataForApp,omitempty"`
 }
@@ -140,12 +140,12 @@ type UserPlaneInformation struct {
 
 // UPNode represent the user plane node
 type UPNode struct {
-	Type                 string                     `yaml:"type"`
-	NodeID               string                     `yaml:"node_id"`
-	ANIP                 string                     `yaml:"an_ip"`
-	Dnn                  string                     `yaml:"dnn"`
-	SNssaiInfos          []models.SnssaiUpfInfoItem `yaml:"sNssaiUpfInfos,omitempty"`
-	InterfaceUpfInfoList []InterfaceUpfInfoItem     `yaml:"interfaces,omitempty"`
+	Type                 string                 `yaml:"type"`
+	NodeID               string                 `yaml:"node_id"`
+	ANIP                 string                 `yaml:"an_ip"`
+	Dnn                  string                 `yaml:"dnn"`
+	SNssaiInfos          []SnssaiUpfInfoItem    `yaml:"sNssaiUpfInfos,omitempty"`
+	InterfaceUpfInfoList []InterfaceUpfInfoItem `yaml:"interfaces,omitempty"`
 }
 
 type InterfaceUpfInfoItem struct {
@@ -154,9 +154,31 @@ type InterfaceUpfInfoItem struct {
 	NetworkInstance string                 `yaml:"networkInstance"`
 }
 
+type SnssaiUpfInfoItem struct {
+	SNssai         *models.Snssai   `json:"sNssai" yaml:"sNssai" bson:"sNssai" mapstructure:"SNssai"`
+	DnnUpfInfoList []DnnUpfInfoItem `json:"dnnUpfInfoList" yaml:"dnnUpfInfoList" bson:"dnnUpfInfoList" mapstructure:"DnnUpfInfoList"`
+}
+
+type DnnUpfInfoItem struct {
+	Dnn             string                  `json:"dnn" yaml:"dnn" bson:"dnn" mapstructure:"Dnn"`
+	DnaiList        []string                `json:"dnaiList,omitempty" yaml:"dnaiList" bson:"dnaiList" mapstructure:"DnaiList"`
+	PduSessionTypes []models.PduSessionType `json:"pduSessionTypes,omitempty" yaml:"pduSessionTypes" bson:"pduSessionTypes" mapstructure:"PduSessionTypes"`
+	Pools           []UEIPPool              `yaml:"pools"`
+}
+
 type UPLink struct {
 	A string `yaml:"A"`
 	B string `yaml:"B"`
+}
+
+type UEIPPool struct {
+	Cidr string `yaml:"cidr"`
+}
+
+type SpecificPath struct {
+	DestinationIP   string   `yaml:"dest,omitempty"`
+	DestinationPort string   `yaml:"DestinationPort,omitempty"`
+	Path            []string `yaml:"path"`
 }
 
 func (c *Config) GetVersion() string {

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -2,6 +2,7 @@ package producer
 
 import (
 	"context"
+	"net"
 	"net/http"
 
 	"github.com/antihax/optional"
@@ -72,13 +73,70 @@ func HandlePDUSessionSMContextCreate(request models.PostSmContextsRequest) *http
 	}
 
 	// IP Allocation
-	if ip, err := smContext.DNNInfo.UeIPAllocator.Allocate(); err != nil {
-		logger.PduSessLog.Errorln("failed allocate IP address for this SM:", err)
+	upfSelectionParams := &smf_context.UPFSelectionParams{
+		Dnn: createData.Dnn,
+		SNssai: &smf_context.SNssai{
+			Sst: createData.SNssai.Sst,
+			Sd:  createData.SNssai.Sd,
+		},
+	}
+	var selectedUPF *smf_context.UPNode
+	var ip net.IP
+	selectedUPFName := ""
+	if smf_context.SMF_Self().ULCLSupport && smf_context.CheckUEHasPreConfig(createData.Supi) {
+		groupName := smf_context.GetULCLGroupNameFromSUPI(createData.Supi)
+		defaultPathPool := smf_context.GetUEDefaultPathPool(groupName)
+		if defaultPathPool != nil {
+			selectedUPFName, ip = defaultPathPool.SelectUPFAndAllocUEIPForULCL(smf_context.GetUserPlaneInformation(), upfSelectionParams)
+			selectedUPF = smf_context.GetUserPlaneInformation().UPFs[selectedUPFName]
+		}
 	} else {
+		selectedUPF, ip = smf_context.GetUserPlaneInformation().SelectUPFAndAllocUEIP(upfSelectionParams)
 		smContext.PDUAddress = ip
 		logger.PduSessLog.Infof("UE[%s] PDUSessionID[%d] IP[%s]",
 			smContext.Supi, smContext.PDUSessionID, smContext.PDUAddress.String())
 	}
+	if ip == nil && (selectedUPF == nil || selectedUPFName == "") {
+		logger.PduSessLog.Error("failed allocate IP address for this SM")
+
+		smContext.SMContextState = smf_context.InActive
+		logger.CtxLog.Traceln("SMContextState Change State: ", smContext.SMContextState.String())
+		logger.PduSessLog.Warnf("Data Path not found\n")
+		logger.PduSessLog.Warnln("Selection Parameter: ", upfSelectionParams.String())
+
+		var httpResponse *http_wrapper.Response
+		if buf, err := smf_context.
+			BuildGSMPDUSessionEstablishmentReject(
+				smContext,
+				nasMessage.Cause5GSMInsufficientResourcesForSpecificSliceAndDNN); err != nil {
+			httpResponse = &http_wrapper.Response{
+				Header: nil,
+				Status: http.StatusForbidden,
+				Body: models.PostSmContextsErrorResponse{
+					JsonData: &models.SmContextCreateError{
+						Error:   &Nsmf_PDUSession.InsufficientResourceSliceDnn,
+						N1SmMsg: &models.RefToBinaryData{ContentId: "n1SmMsg"},
+					},
+				},
+			}
+		} else {
+			httpResponse = &http_wrapper.Response{
+				Header: nil,
+				Status: http.StatusForbidden,
+				Body: models.PostSmContextsErrorResponse{
+					JsonData: &models.SmContextCreateError{
+						Error:   &Nsmf_PDUSession.InsufficientResourceSliceDnn,
+						N1SmMsg: &models.RefToBinaryData{ContentId: "n1SmMsg"},
+					},
+					BinaryDataN1SmMessage: buf,
+				},
+			}
+		}
+
+		return httpResponse
+	}
+	smContext.PDUAddress = ip
+	smContext.SelectedUPF = selectedUPF
 
 	smPlmnID := createData.Guami.PlmnId
 
@@ -129,17 +187,10 @@ func HandlePDUSessionSMContextCreate(request models.PostSmContextsRequest) *http
 		logger.PduSessLog.Errorf("apply sm policy decision error: %+v", err)
 	}
 	var defaultPath *smf_context.DataPath
-	upfSelectionParams := &smf_context.UPFSelectionParams{
-		Dnn: createData.Dnn,
-		SNssai: &smf_context.SNssai{
-			Sst: createData.SNssai.Sst,
-			Sd:  createData.SNssai.Sd,
-		},
-	}
 
 	if smf_context.SMF_Self().ULCLSupport && smf_context.CheckUEHasPreConfig(createData.Supi) {
 		logger.PduSessLog.Infof("SUPI[%s] has pre-config route", createData.Supi)
-		uePreConfigPaths := smf_context.GetUEPreConfigPaths(createData.Supi)
+		uePreConfigPaths := smf_context.GetUEPreConfigPaths(createData.Supi, selectedUPFName)
 		smContext.Tunnel.DataPathPool = uePreConfigPaths.DataPathPool
 		smContext.Tunnel.PathIDGenerator = uePreConfigPaths.PathIDGenerator
 		defaultPath = smContext.Tunnel.DataPathPool.GetDefaultPath()
@@ -149,7 +200,8 @@ func HandlePDUSessionSMContextCreate(request models.PostSmContextsRequest) *http
 		// UE has no pre-config path.
 		// Use default route
 		logger.PduSessLog.Infof("SUPI[%s] has no pre-config route", createData.Supi)
-		defaultUPPath := smf_context.GetUserPlaneInformation().GetDefaultUserPlanePathByDNN(upfSelectionParams)
+		defaultUPPath := smf_context.GetUserPlaneInformation().GetDefaultUserPlanePathByDNNAndUPF(
+			upfSelectionParams, smContext.SelectedUPF)
 		defaultPath = smf_context.GenerateDataPath(defaultUPPath, smContext)
 		if defaultPath != nil {
 			defaultPath.IsDefaultPath = true
@@ -289,6 +341,11 @@ func HandlePDUSessionSMContextUpdate(smContextRef string, body models.UpdateSmCo
 			}
 
 			smContext.HandlePDUSessionReleaseRequest(m.PDUSessionReleaseRequest)
+			if smContext.SelectedUPF != nil {
+				logger.PduSessLog.Infof("UE[%s] PDUSessionID[%d] Release IP[%s]",
+					smContext.Supi, smContext.PDUSessionID, smContext.PDUAddress.String())
+				smf_context.GetUserPlaneInformation().ReleaseUEIP(smContext.SelectedUPF, smContext.PDUAddress)
+			}
 			if buf, err := smf_context.BuildGSMPDUSessionReleaseCommand(smContext); err != nil {
 				logger.PduSessLog.Errorf("Build GSM PDUSessionReleaseCommand failed: %+v", err)
 			} else {

--- a/smf.go
+++ b/smf.go
@@ -11,7 +11,9 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -37,6 +39,7 @@ func main() {
 	app.Usage = "-free5gccfg common configuration file -smfcfg smf configuration file"
 	app.Action = action
 	app.Flags = SMF.GetCliCmd()
+	rand.Seed(time.Now().UnixNano())
 
 	if err := app.Run(os.Args); err != nil {
 		appLog.Errorf("SMF Run error: %v", err)


### PR DESCRIPTION
# Multiple UPF and ULCL feature
This PR is for getting higher throughput by multple UPFs.

This PR enables:

* Manage multiple UPFs
* Each UPF has one or more IP pools.
* Each IP pool has a range for allocating IP address, e.g. 60.1.0.0/16.
* Manage IP address allocation and release of each IP pool.
* SMF selects a UPF according to both DNN and S-NSSAI contained within a SM Context Create Request message when creating a new SM context.
* Supports ULCL feature with separated datapath topology.