### PR TITLE
Add locality in config and NF Profile of SMF

### DIFF
--- a/consumer/nnrf.go
+++ b/consumer/nnrf.go
@@ -35,6 +35,9 @@ func SendNFRegistration() error {
 		SmfInfo:       smf_context.SmfInfo,
 		SNssais:       &sNssais,
 	}
+	if smf_context.SMF_Self().Locality != "" {
+		profile.Locality = smf_context.SMF_Self().Locality
+	}
 	var rep models.NfProfile
 	var res *http.Response
 	var err error

--- a/context/context.go
+++ b/context/context.go
@@ -47,6 +47,7 @@ type SMFContext struct {
 	NFManagementClient             *Nnrf_NFManagement.APIClient
 	NFDiscoveryClient              *Nnrf_NFDiscovery.APIClient
 	SubscriberDataManagementClient *Nudm_SubscriberDataManagement.APIClient
+	Locality                       string
 
 	UserPlaneInformation *UserPlaneInformation
 
@@ -191,6 +192,8 @@ func InitSmfContext(config *factory.Config) {
 	smfContext.UserPlaneInformation = NewUserPlaneInformation(&configuration.UserPlaneInformation)
 
 	SetupNFProfile(config)
+
+	smfContext.Locality = configuration.Locality
 }
 
 func InitSMFUERouting(routingConfig *factory.RoutingConfig) {

--- a/factory/config.go
+++ b/factory/config.go
@@ -42,6 +42,7 @@ type Configuration struct {
 	ServiceNameList      []string             `yaml:"serviceNameList,omitempty"`
 	SNssaiInfo           []SnssaiInfoItem     `yaml:"snssaiInfos,omitempty"`
 	ULCL                 bool                 `yaml:"ulcl,omitempty"`
+	Locality             string               `yaml:"locality,omitempty"`
 }
 
 type SnssaiInfoItem struct {


### PR DESCRIPTION
This PR adds locality in the NF Profile of SMF.
If locality is missing, SMF registeres to NRF in a similar way so far.