### PR TITLE
PDU session establishment supports UP security mechanisms

### DIFF
--- a/context/gsm_handler.go
+++ b/context/gsm_handler.go
@@ -3,6 +3,7 @@ package context
 import (
 	"github.com/free5gc/nas/nasConvert"
 	"github.com/free5gc/nas/nasMessage"
+	"github.com/free5gc/openapi/models"
 	"github.com/free5gc/smf/logger"
 )
 
@@ -13,6 +14,24 @@ func (smContext *SMContext) HandlePDUSessionEstablishmentRequest(req *nasMessage
 
 	// Retrieve PTI (Procedure transaction identity)
 	smContext.Pti = req.GetPTI()
+
+	// Retrieve MaxIntegrityProtectedDataRate of UE for UP Security
+	switch req.GetMaximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink() {
+	case 0x00:
+		smContext.MaximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink =
+			models.MaxIntegrityProtectedDataRate__64_KBPS
+	case 0xff:
+		smContext.MaximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink =
+			models.MaxIntegrityProtectedDataRate_MAX_UE_RATE
+	}
+	switch req.GetMaximumDataRatePerUEForUserPlaneIntegrityProtectionForDownLink() {
+	case 0x00:
+		smContext.MaximumDataRatePerUEForUserPlaneIntegrityProtectionForDownLink =
+			models.MaxIntegrityProtectedDataRate__64_KBPS
+	case 0xff:
+		smContext.MaximumDataRatePerUEForUserPlaneIntegrityProtectionForDownLink =
+			models.MaxIntegrityProtectedDataRate_MAX_UE_RATE
+	}
 
 	// Handle PDUSessionType
 	if req.PDUSessionType != nil {

--- a/context/ngap_build.go
+++ b/context/ngap_build.go
@@ -7,6 +7,7 @@ import (
 	"github.com/free5gc/aper"
 	"github.com/free5gc/ngap/ngapConvert"
 	"github.com/free5gc/ngap/ngapType"
+	"github.com/free5gc/openapi/models"
 )
 
 const DefaultNonGBR5QI = 9
@@ -119,8 +120,65 @@ func BuildPDUSessionResourceSetupRequestTransfer(ctx *SMContext) ([]byte, error)
 			},
 		},
 	}
-
 	resourceSetupRequestTransfer.ProtocolIEs.List = append(resourceSetupRequestTransfer.ProtocolIEs.List, ie)
+
+	// Security Indication to NG-RAN (optional) TS 38.413 9.3.1.27
+	// Only over 3GPP access TS 23.501 5.10.3
+	if ctx.AnType == models.AccessType__3_GPP_ACCESS && ctx.UpSecurity != nil {
+		upSecurity := ctx.UpSecurity
+		maximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink :=
+			ctx.MaximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink
+
+		ie = ngapType.PDUSessionResourceSetupRequestTransferIEs{}
+		ie.Id.Value = ngapType.ProtocolIEIDSecurityIndication
+		ie.Criticality.Value = ngapType.CriticalityPresentReject
+
+		securityIndication := new(ngapType.SecurityIndication)
+
+		switch upSecurity.UpIntegr {
+		case models.UpIntegrity_REQUIRED:
+			securityIndication.IntegrityProtectionIndication.Value =
+				ngapType.IntegrityProtectionIndicationPresentRequired
+		case models.UpIntegrity_PREFERRED:
+			securityIndication.IntegrityProtectionIndication.Value =
+				ngapType.IntegrityProtectionIndicationPresentPreferred
+		case models.UpIntegrity_NOT_NEEDED:
+			securityIndication.IntegrityProtectionIndication.Value =
+				ngapType.IntegrityProtectionIndicationPresentNotNeeded
+		}
+		switch upSecurity.UpConfid {
+		case models.UpConfidentiality_REQUIRED:
+			securityIndication.ConfidentialityProtectionIndication.Value =
+				ngapType.ConfidentialityProtectionIndicationPresentRequired
+		case models.UpConfidentiality_PREFERRED:
+			securityIndication.ConfidentialityProtectionIndication.Value =
+				ngapType.ConfidentialityProtectionIndicationPresentPreferred
+		case models.UpConfidentiality_NOT_NEEDED:
+			securityIndication.ConfidentialityProtectionIndication.Value =
+				ngapType.ConfidentialityProtectionIndicationPresentNotNeeded
+		}
+
+		// Present only when Integrity Indication within the Security Indication is set to "required" or "preferred"
+		integrityProtectionInd := securityIndication.IntegrityProtectionIndication.Value
+		if integrityProtectionInd == ngapType.IntegrityProtectionIndicationPresentRequired ||
+			integrityProtectionInd == ngapType.IntegrityProtectionIndicationPresentPreferred {
+			securityIndication.MaximumIntegrityProtectedDataRateUL = new(ngapType.MaximumIntegrityProtectedDataRate)
+			switch maximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink {
+			case models.MaxIntegrityProtectedDataRate_MAX_UE_RATE:
+				securityIndication.MaximumIntegrityProtectedDataRateUL.Value =
+					ngapType.MaximumIntegrityProtectedDataRatePresentMaximumUERate
+			case models.MaxIntegrityProtectedDataRate__64_KBPS:
+				securityIndication.MaximumIntegrityProtectedDataRateUL.Value =
+					ngapType.MaximumIntegrityProtectedDataRatePresentBitrate64kbs
+			}
+		}
+
+		ie.Value = ngapType.PDUSessionResourceSetupRequestTransferIEsValue{
+			Present:            ngapType.PDUSessionResourceSetupRequestTransferIEsPresentSecurityIndication,
+			SecurityIndication: securityIndication,
+		}
+		resourceSetupRequestTransfer.ProtocolIEs.List = append(resourceSetupRequestTransfer.ProtocolIEs.List, ie)
+	}
 
 	if buf, err := aper.MarshalWithParams(resourceSetupRequestTransfer, "valueExt"); err != nil {
 		return nil, fmt.Errorf("encode resourceSetupRequestTransfer failed: %s", err)

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -83,6 +83,11 @@ type SMContext struct {
 
 	DnnConfiguration models.DnnConfiguration
 
+	// UP Security support TS 29.502 R16 6.1.6.2.39
+	UpSecurity                                                     *models.UpSecurity
+	MaximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink   models.MaxIntegrityProtectedDataRate
+	MaximumDataRatePerUEForUserPlaneIntegrityProtectionForDownLink models.MaxIntegrityProtectedDataRate
+
 	// Client
 	SMPolicyClient      *Npcf_SMPolicyControl.APIClient
 	CommunicationClient *Namf_Communication.APIClient

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -161,6 +161,10 @@ func HandlePDUSessionSMContextCreate(request models.PostSmContextsRequest) *http
 		}()
 		if len(sessSubData) > 0 {
 			smContext.DnnConfiguration = sessSubData[0].DnnConfigurations[smContext.Dnn]
+			// UP Security info present in session management subscription data
+			if smContext.DnnConfiguration.UpSecurity != nil {
+				smContext.UpSecurity = smContext.DnnConfiguration.UpSecurity
+			}
 		} else {
 			logger.PduSessLog.Errorln("SessionManagementSubscriptionData from UDM is nil")
 		}


### PR DESCRIPTION
SMF can get UP Security Policy from session management subscription data in the PDU session establishment procedure, and provide UP Security indication to NG-RAN.