### PR TITLE
Select PCF by locality

### DIFF
--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/antihax/optional"
 	"github.com/google/uuid"
 
 	"github.com/free5gc/nas/nasConvert"
@@ -244,6 +245,10 @@ func (smContext *SMContext) PDUAddressToNAS() (addr [12]byte, addrLen uint8) {
 func (smContext *SMContext) PCFSelection() error {
 	// Send NFDiscovery for find PCF
 	localVarOptionals := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{}
+
+	if SMF_Self().Locality != "" {
+		localVarOptionals.PreferredLocality = optional.NewString(SMF_Self().Locality)
+	}
 
 	rep, res, err := SMF_Self().
 		NFDiscoveryClient.


### PR DESCRIPTION
This PR makes SMF to select PCF by locality.
If locality is missing, SMF selects PCF in a similar way so far.
