### PR TITLE
Fix association infinite loop by using time.After() and select.

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -51,6 +51,7 @@ type SMFContext struct {
 	SubscriberDataManagementClient      *Nudm_SubscriberDataManagement.APIClient
 	Locality                            string
 	AssociationSetupFailedAlertInterval time.Duration
+	AssociationSetupFailedRetryInterval time.Duration
 
 	UserPlaneInformation  *UserPlaneInformation
 	PFCPCancelFunc        context.CancelFunc
@@ -166,6 +167,11 @@ func InitSmfContext(config *factory.Config) {
 			smfContext.AssociationSetupFailedAlertInterval = 5 * time.Minute
 		} else {
 			smfContext.AssociationSetupFailedAlertInterval = pfcp.AlertInterval
+		}
+		if pfcp.RetryInterval == 0 {
+			smfContext.AssociationSetupFailedRetryInterval = 5 * time.Second
+		} else {
+			smfContext.AssociationSetupFailedRetryInterval = pfcp.RetryInterval
 		}
 	}
 

--- a/internal/pfcp/udp/udp.go
+++ b/internal/pfcp/udp/udp.go
@@ -1,6 +1,7 @@
 package udp
 
 import (
+	"errors"
 	"net"
 	"time"
 
@@ -53,5 +54,8 @@ func SendPfcpResponse(sndMsg *pfcp.Message, addr *net.UDPAddr) {
 }
 
 func SendPfcpRequest(sndMsg *pfcp.Message, addr *net.UDPAddr) (rsvMsg *pfcpUdp.Message, err error) {
+	if addr.IP.Equal(net.IPv4zero) {
+		return nil, errors.New("no destination IP address is specified")
+	}
 	return Server.WriteRequestTo(sndMsg, addr)
 }

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -214,6 +214,7 @@ type PFCP struct {
 	Port uint16 `yaml:"port,omitempty" valid:"port,optional"`
 	// interval at which PFCP Association Setup error messages are output.
 	AlertInterval time.Duration `yaml:"associationSetupFailedAlertInterval,omitempty" valid:"type(time.Duration),optional"`
+	RetryInterval time.Duration `yaml:"associationSetupFailedRetryInterval,omitempty" valid:"type(time.Duration),optional"`
 	Heartbeat     PfcpHeartbeat `yaml:"heartbeat,omitempty" valid:"optional"`
 }
 

--- a/pkg/service/association.go
+++ b/pkg/service/association.go
@@ -62,19 +62,19 @@ func ensureSetupPfcpAssociation(ctx context.Context, upf *smf_context.UPF, upfSt
 	alertInterval := smf_context.SMF_Self().AssociationSetupFailedAlertInterval
 	retryInterval := smf_context.SMF_Self().AssociationSetupFailedRetryInterval
 	for {
+		timer := time.After(retryInterval)
 		err := setupPfcpAssociation(upf, upfStr)
 		if err == nil {
 			return
 		}
-		logger.AppLog.Errorf("Failed to setup an association with UPF%s, error:%+v", upfStr, err)
+		logger.AppLog.Warnf("Failed to setup an association with UPF%s, error:%+v", upfStr, err)
 		now := time.Now()
 		logger.AppLog.Debugf("now %+v, alertTime %+v", now, alertTime)
 		if now.After(alertTime.Add(alertInterval)) {
 			logger.AppLog.Errorf("ALERT for UPF%s", upfStr)
 			alertTime = now
 		}
-		logger.AppLog.Errorf("Wait %+v until next retry attempt", retryInterval)
-		timer := time.After(retryInterval)
+		logger.AppLog.Debugf("Wait %+v (or less) until next retry attempt", retryInterval)
 		select {
 		case <-ctx.Done():
 			logger.AppLog.Infof("Canceled association request to UPF%s", upfStr)


### PR DESCRIPTION
Hi,

This PR attempts to fix issue https://github.com/free5gc/smf/issues/66.

It uses `time.After()` and `select` - to wait between association attempts. It is done in a similar manner as in method (`keepHeartbeatTo`).

I tested it and it works well in my environment (Ubuntu 20.4 VM with free5gc-compose.).
