### PR TITLE
Add Delete REST API to user_plane_information (upNodes, links).

### DIFF
--- a/internal/context/upf.go
+++ b/internal/context/upf.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -69,6 +70,10 @@ type UPF struct {
 	UPIPInfo          pfcpType.UserPlaneIPResourceInformation
 	UPFStatus         UPFStatus
 	RecoveryTimeStamp time.Time
+
+	Ctx               context.Context
+	CancelFunc        context.CancelFunc
+
 	SNssaiInfos       []SnssaiUPFInfo
 	N3Interfaces      []UPFInterfaceInfo
 	N9Interfaces      []UPFInterfaceInfo

--- a/internal/context/upf.go
+++ b/internal/context/upf.go
@@ -71,12 +71,12 @@ type UPF struct {
 	UPFStatus         UPFStatus
 	RecoveryTimeStamp time.Time
 
-	Ctx               context.Context
-	CancelFunc        context.CancelFunc
+	Ctx        context.Context
+	CancelFunc context.CancelFunc
 
-	SNssaiInfos       []SnssaiUPFInfo
-	N3Interfaces      []UPFInterfaceInfo
-	N9Interfaces      []UPFInterfaceInfo
+	SNssaiInfos  []SnssaiUPFInfo
+	N3Interfaces []UPFInterfaceInfo
+	N9Interfaces []UPFInterfaceInfo
 
 	pdrPool sync.Map
 	farPool sync.Map
@@ -131,7 +131,7 @@ func NewUPFInterfaceInfo(i *factory.InterfaceUpfInfoItem) *UPFInterfaceInfo {
 	return interfaceInfo
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 // IP returns the IP of the user plane IP information of the pduSessType
 func (i *UPFInterfaceInfo) IP(pduSessType uint8) (net.IP, error) {
 	if (pduSessType == nasMessage.PDUSessionTypeIPv4 ||
@@ -202,7 +202,7 @@ func NewUPTunnel() (tunnel *UPTunnel) {
 	return
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 func (upTunnel *UPTunnel) AddDataPath(dataPath *DataPath) {
 	pathID, err := upTunnel.PathIDGenerator.Allocate()
 	if err != nil {
@@ -213,7 +213,7 @@ func (upTunnel *UPTunnel) AddDataPath(dataPath *DataPath) {
 	upTunnel.DataPathPool[pathID] = dataPath
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 // NewUPF returns a new UPF context in SMF
 func NewUPF(nodeID *pfcpType.NodeID, ifaces []factory.InterfaceUpfInfoItem) (upf *UPF) {
 	upf = new(UPF)
@@ -248,7 +248,7 @@ func NewUPF(nodeID *pfcpType.NodeID, ifaces []factory.InterfaceUpfInfoItem) (upf
 	return upf
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 // GetInterface return the UPFInterfaceInfo that match input cond
 func (upf *UPF) GetInterface(interfaceType models.UpInterfaceType, dnn string) *UPFInterfaceInfo {
 	switch interfaceType {
@@ -291,7 +291,7 @@ func (upf *UPF) PFCPAddr() *net.UDPAddr {
 	}
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 func RetrieveUPFNodeByNodeID(nodeID pfcpType.NodeID) *UPF {
 	var targetUPF *UPF = nil
 	upfPool.Range(func(key, value interface{}) bool {
@@ -315,7 +315,7 @@ func RetrieveUPFNodeByNodeID(nodeID pfcpType.NodeID) *UPF {
 	return targetUPF
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 func RemoveUPFNodeByNodeID(nodeID pfcpType.NodeID) bool {
 	upfID := ""
 	upfPool.Range(func(key, value interface{}) bool {
@@ -503,7 +503,7 @@ func (upf *UPF) AddQER() (*QER, error) {
 	return qer, nil
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 func (upf *UPF) RemovePDR(pdr *PDR) (err error) {
 	if upf.UPFStatus != AssociatedSetUpSuccess {
 		err = fmt.Errorf("this upf not associate with smf")
@@ -515,7 +515,7 @@ func (upf *UPF) RemovePDR(pdr *PDR) (err error) {
 	return nil
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 func (upf *UPF) RemoveFAR(far *FAR) (err error) {
 	if upf.UPFStatus != AssociatedSetUpSuccess {
 		err = fmt.Errorf("this upf not associate with smf")
@@ -527,7 +527,7 @@ func (upf *UPF) RemoveFAR(far *FAR) (err error) {
 	return nil
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 func (upf *UPF) RemoveBAR(bar *BAR) (err error) {
 	if upf.UPFStatus != AssociatedSetUpSuccess {
 		err = fmt.Errorf("this upf not associate with smf")
@@ -539,7 +539,7 @@ func (upf *UPF) RemoveBAR(bar *BAR) (err error) {
 	return nil
 }
 
-//*** add unit test ***//
+// *** add unit test ***//
 func (upf *UPF) RemoveQER(qer *QER) (err error) {
 	if upf.UPFStatus != AssociatedSetUpSuccess {
 		err = fmt.Errorf("this upf not associate with smf")

--- a/internal/context/user_plane_information.go
+++ b/internal/context/user_plane_information.go
@@ -453,7 +453,7 @@ func (upi *UserPlaneInformation) UpNodeDelete(upNodeName string) {
 
 		// update links
 		for name, n := range upi.UPNodes {
-			if index := nodeInLink (upNode, n.Links); index != -1 {
+			if index := nodeInLink(upNode, n.Links); index != -1 {
 				logger.InitLog.Infof("Delete UPLink [%s] <=> [%s].\n", name, upNodeName)
 				n.Links = removeNodeFromLink(n.Links, index)
 			}

--- a/internal/context/user_plane_information.go
+++ b/internal/context/user_plane_information.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"reflect"
 	"sort"
+	"sync"
 
 	"github.com/free5gc/openapi/models"
 	"github.com/free5gc/pfcp/pfcpType"
@@ -19,6 +20,7 @@ import (
 
 // UserPlaneInformation store userplane topology
 type UserPlaneInformation struct {
+	Mu                        sync.RWMutex // protect UPF and topology structure
 	UPNodes                   map[string]*UPNode
 	UPFs                      map[string]*UPNode
 	AccessNetwork             map[string]*UPNode

--- a/internal/context/user_plane_information.go
+++ b/internal/context/user_plane_information.go
@@ -428,11 +428,12 @@ func (upi *UserPlaneInformation) UpNodeDelete(upfName string) (found bool) {
 	found = false
 	if ok {
 		found = true
+		logger.InitLog.Infof("UPNode [%s] found. Deleting it.\n", upfName)
 		if upNode.Type == UPNODE_UPF {
-			logger.InitLog.Infof("UPF [%s] found. Remove its NodeID.\n", upfName)
+			logger.InitLog.Tracef("Delete UPF [%s] from its NodeID.\n", upfName)
 			RemoveUPFNodeByNodeID(upNode.UPF.NodeID)
 			if _, ok = upi.UPFs[upfName]; ok {
-				logger.InitLog.Infof("UPF [%s] found. Remove it from upi.UPFs.\n", upfName)
+				logger.InitLog.Tracef("Delete UPF [%s] from upi.UPFs.\n", upfName)
 				delete(upi.UPFs, upfName)
 			}
 			for selectionStr, destMap := range upi.DefaultUserPlanePathToUPF {
@@ -444,7 +445,7 @@ func (upi *UserPlaneInformation) UpNodeDelete(upfName string) (found bool) {
 				}
 			}
 		}
-		logger.InitLog.Infof("UPNode [%s] found. Remove it from upi.UPNodes.\n", upfName)
+		logger.InitLog.Tracef("Delete UPNode [%s] from upi.UPNodes.\n", upfName)
 		delete(upi.UPNodes, upfName)
 	} else {
 		return
@@ -453,7 +454,7 @@ func (upi *UserPlaneInformation) UpNodeDelete(upfName string) (found bool) {
 	// update links
 	for name, n := range upi.UPNodes {
 		if index := nodeInLink (upNode, n.Links); index != -1 {
-			logger.InitLog.Infof("UPLink [%s] <=> [%s] found. Removing it.\n", name, upfName)
+			logger.InitLog.Infof("Delete UPLink [%s] <=> [%s].\n", name, upfName)
 			n.Links = removeNodeFromLink(n.Links, index)
 		}
 	}

--- a/internal/sbi/producer/pdu_session.go
+++ b/internal/sbi/producer/pdu_session.go
@@ -62,7 +62,7 @@ func HandlePDUSessionSMContextCreate(request models.PostSmContextsRequest) *http
 
 	upi := smf_context.GetUserPlaneInformation()
 	upi.Mu.RLock()
-	defer upi.Mu.RUnlock()	
+	defer upi.Mu.RUnlock()
 
 	// DNN Information from config
 	smContext.DNNInfo = smf_context.RetrieveDnnInformation(createData.SNssai, createData.Dnn)

--- a/internal/sbi/upi/api_upi.go
+++ b/internal/sbi/upi/api_upi.go
@@ -61,16 +61,16 @@ func DeleteUpNodeLink(c *gin.Context) {
 		c.JSON(http.StatusForbidden, gin.H{})
 	} else {
 		req := httpwrapper.NewRequest(c.Request, nil)
-		req.Params["upfRef"] = c.Params.ByName("upfRef")
-		upfRef := req.Params["upfRef"]
+		req.Params["upNodeRef"] = c.Params.ByName("upNodeRef")
+		upNodeRef := req.Params["upNodeRef"]
 		upi := smf_context.SMF_Self().UserPlaneInformation
 		upi.Mu.Lock()
 		defer upi.Mu.Unlock()
-		if upNode, ok := upi.UPNodes[upfRef]; ok {
+		if upNode, ok := upi.UPNodes[upNodeRef]; ok {
 			if upNode.Type == smf_context.UPNODE_UPF {
 				go association.ReleaseAllResourcesOfUPF(upNode.UPF)
 			}
-			upi.UpNodeDelete(upfRef)
+			upi.UpNodeDelete(upNodeRef)
 			c.JSON(http.StatusOK, gin.H{"status": "OK"})
 		} else {
 			c.JSON(http.StatusNotFound, gin.H{})

--- a/internal/sbi/upi/api_upi.go
+++ b/internal/sbi/upi/api_upi.go
@@ -1,6 +1,7 @@
 package upi
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -49,6 +50,7 @@ func PostUpNodesLinks(c *gin.Context) {
 	for _, upf := range upi.UPFs {
 		// only associate new ones
 		if upf.UPF.UPFStatus == smf_context.NotAssociated {
+			upf.UPF.Ctx, upf.UPF.CancelFunc = context.WithCancel(context.Background())
 			go association.ToBeAssociatedWithUPF(smf_context.SMF_Self().Ctx, upf.UPF)
 		}
 	}
@@ -71,6 +73,7 @@ func DeleteUpNodeLink(c *gin.Context) {
 				go association.ReleaseAllResourcesOfUPF(upNode.UPF)
 			}
 			upi.UpNodeDelete(upNodeRef)
+			upNode.UPF.CancelFunc()
 			c.JSON(http.StatusOK, gin.H{"status": "OK"})
 		} else {
 			c.JSON(http.StatusNotFound, gin.H{})

--- a/internal/sbi/upi/routers.go
+++ b/internal/sbi/upi/routers.go
@@ -75,7 +75,7 @@ var routes = Routes{
 	{
 		"DeleteUpNodeLink",
 		strings.ToUpper("Delete"),
-		"/upNodesLinks/:upfRef",
+		"/upNodesLinks/:upNodeRef",
 		DeleteUpNodeLink,
 	},
 }

--- a/internal/sbi/upi/routers.go
+++ b/internal/sbi/upi/routers.go
@@ -41,6 +41,8 @@ func AddService(engine *gin.Engine) *gin.RouterGroup {
 			group.GET(route.Pattern, route.HandlerFunc)
 		case "POST":
 			group.POST(route.Pattern, route.HandlerFunc)
+		case "DELETE":
+			group.DELETE(route.Pattern, route.HandlerFunc)
 		}
 	}
 	return group
@@ -69,5 +71,11 @@ var routes = Routes{
 		strings.ToUpper("Get"),
 		"/upNodesLinks",
 		GetUpNodesLinks,
+	},
+	{
+		"DeleteUpNodeLink",
+		strings.ToUpper("Delete"),
+		"/upNodesLinks/:upfRef",
+		DeleteUpNodeLink,
 	},
 }

--- a/pkg/association/association.go
+++ b/pkg/association/association.go
@@ -48,6 +48,16 @@ func ToBeAssociatedWithUPF(ctx context.Context, upf *smf_context.UPF) {
 	}
 }
 
+func ReleaseAllResourcesOfUPF(upf *smf_context.UPF) {
+	var upfStr string
+	if upf.NodeID.NodeIdType == pfcpType.NodeIdTypeFqdn {
+		upfStr = fmt.Sprintf("[%s](%s)", upf.NodeID.FQDN, upf.NodeID.ResolveNodeIdToIp().String())
+	} else {
+		upfStr = fmt.Sprintf("[%s]", upf.NodeID.ResolveNodeIdToIp().String())
+	}
+	releaseAllResourcesOfUPF(upf, upfStr)
+}
+
 func isDone(ctx context.Context) bool {
 	select {
 	case <-ctx.Done():
@@ -171,7 +181,7 @@ func doPfcpHeartbeat(upf *smf_context.UPF, upfStr string) error {
 }
 
 func releaseAllResourcesOfUPF(upf *smf_context.UPF, upfStr string) {
-	logger.AppLog.Infof("Release all resources of UPF%s", upfStr)
+	logger.AppLog.Infof("Release all resources of UPF %s", upfStr)
 
 	upf.ProcEachSMContext(func(smContext *smf_context.SMContext) {
 		smContext.SMLock.Lock()

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -273,6 +273,7 @@ func (smf *SMF) Start() {
 	smf_context.SMF_Self().Ctx = ctx
 	smf_context.SMF_Self().PFCPCancelFunc = cancel
 	for _, upNode := range smf_context.SMF_Self().UserPlaneInformation.UPFs {
+		upNode.UPF.Ctx, upNode.UPF.CancelFunc = context.WithCancel(context.Background())
 		go association.ToBeAssociatedWithUPF(ctx, upNode.UPF)
 	}
 


### PR DESCRIPTION
This PR is in a continuation of PR https://github.com/free5gc/smf/pull/68 which adds delete Rest API support.

* [DELETE] /upi/v1/upNodesLinks/<upNode name>

### Delete upNode

Delete an upNode and its associated links from user_plane_information

```
curl -H "Content-type: application/json" -X DELETE http://<smf_ip_address>:<smf_port>/upi/v1/upNodesLinks/<upnode_name>
```

REST path:

```
    smf_ip_address - ipaddress of SMF service
    smf_port       - the service port
    upnode_name    - the name of the upNode that represents the upNode to be removed
```
Return:

```
    status - 200, 404
```
