### PR TITLE
Fix staticPools behavior

### DIFF
--- a/internal/context/pool/lazyReusePool.go
+++ b/internal/context/pool/lazyReusePool.go
@@ -192,6 +192,8 @@ func (p *LazyReusePool) Reserve(first, last int) error {
 			} else {
 				p.head = cur.next
 			}
+			// do not update prev
+			continue
 		}
 
 		prev = cur

--- a/internal/context/pool/lazyReusePool.go
+++ b/internal/context/pool/lazyReusePool.go
@@ -178,6 +178,7 @@ func (p *LazyReusePool) Reserve(first, last int) error {
 			cur.next = &segment{
 				first: last + 1,
 				last:  cur.last,
+				next:  cur.next,
 			}
 
 			cur.last = first - 1

--- a/internal/context/pool/lazyReusePool.go
+++ b/internal/context/pool/lazyReusePool.go
@@ -168,12 +168,12 @@ func (p *LazyReusePool) Reserve(first, last int) error {
 
 	for cur, prev := p.head, (*segment)(nil); cur != nil; cur = cur.next {
 		switch {
-		case cur.first == first && cur.last > last:
+		case cur.first >= first && cur.first <= last && cur.last > last:
+			p.remain -= last - cur.first + 1
 			cur.first = last + 1
-			p.remain -= last - first + 1
-		case cur.first < first && cur.last == last:
+		case cur.first < first && cur.last >= first && cur.last <= last:
+			p.remain -= cur.last - first + 1
 			cur.last = first - 1
-			p.remain -= last - first + 1
 		case cur.first < first && cur.last > last:
 			cur.next = &segment{
 				first: last + 1,
@@ -184,10 +184,12 @@ func (p *LazyReusePool) Reserve(first, last int) error {
 			p.remain -= last - first + 1
 
 		// this segment in reserve range
-		case cur.first > first && cur.last < last:
+		case cur.first >= first && cur.last <= last:
 			p.remain -= cur.last - cur.first + 1
 			if prev != nil {
 				prev.next = cur.next
+			} else {
+				p.head = cur.next
 			}
 		}
 

--- a/internal/context/pool/lazyReusePool_test.go
+++ b/internal/context/pool/lazyReusePool_test.go
@@ -355,7 +355,10 @@ func TestLazyReusePool_ReserveSection2(t *testing.T) {
 	err = p.Reserve(60, 65)
 	require.NoError(t, err)
 	assert.Equal(t, (59 - 56 + 1 + 69 - 66 + 1 + 89 - 76 + 1), p.Remain())
-	assert.Equal(t, &segment{first: 56, last: 59, next: &segment{first: 66, last: 69, next: &segment{first: 76, last: 89}}}, p.head)
+	assert.Equal(t, &segment{first: 56, last: 59, next: &segment{
+		first: 66, last: 69,
+		next: &segment{first: 76, last: 89},
+	}}, p.head)
 
 	// remove center segment
 	err = p.Reserve(60, 75)
@@ -390,7 +393,10 @@ func TestLazyReusePool_ReserveSection3(t *testing.T) {
 	err = p.Reserve(60, 69)
 	require.NoError(t, err)
 	require.Equal(t, (19 - 10 + 1 + 39 - 30 + 1 + 59 - 50 + 1 + 99 - 70 + 1), p.Remain())
-	require.Equal(t, &segment{first: 10, last: 19, next: &segment{first: 30, last: 39, next: &segment{first: 50, last: 59, next: &segment{first: 70, last: 99}}}}, p.head)
+	require.Equal(t, &segment{first: 10, last: 19, next: &segment{
+		first: 30, last: 39,
+		next: &segment{first: 50, last: 59, next: &segment{first: 70, last: 99}},
+	}}, p.head)
 
 	// remove two segments
 	err = p.Reserve(30, 59)

--- a/internal/context/pool/lazyReusePool_test.go
+++ b/internal/context/pool/lazyReusePool_test.go
@@ -347,9 +347,12 @@ func TestLazyReusePool_ReserveSection2(t *testing.T) {
 	assert.Equal(t, &segment{first: 56, last: 89}, p.head)
 
 	// generate 3 segments
-	err = p.Reserve(60, 65)
-	require.NoError(t, err)
 	err = p.Reserve(70, 75)
+	require.NoError(t, err)
+	assert.Equal(t, (69 - 56 + 1 + 89 - 76 + 1), p.Remain())
+	assert.Equal(t, &segment{first: 56, last: 69, next: &segment{first: 76, last: 89}}, p.head)
+
+	err = p.Reserve(60, 65)
 	require.NoError(t, err)
 	assert.Equal(t, (59 - 56 + 1 + 69 - 66 + 1 + 89 - 76 + 1), p.Remain())
 	assert.Equal(t, &segment{first: 56, last: 59, next: &segment{first: 66, last: 69, next: &segment{first: 76, last: 89}}}, p.head)

--- a/internal/context/ue_ip_pool_test.go
+++ b/internal/context/ue_ip_pool_test.go
@@ -22,13 +22,13 @@ func TestUeIPPool(t *testing.T) {
 
 	// make allowed ip pools
 	var ipPoolList []net.IP
-	for i := 1; i < 255; i += 1 {
+	for i := 0; i <= 255; i += 1 {
 		ipStr := fmt.Sprintf("10.10.0.%d", i)
 		ipPoolList = append(ipPoolList, net.ParseIP(ipStr).To4())
 	}
 
 	// allocate
-	for i := 1; i < 255; i += 1 {
+	for i := 0; i < 256; i += 1 {
 		allocIP = ueIPPool.allocate(nil)
 		require.Contains(t, ipPoolList, allocIP)
 	}
@@ -38,7 +38,7 @@ func TestUeIPPool(t *testing.T) {
 	require.Nil(t, allocIP)
 
 	// release IP
-	for _, i := range rand.Perm(254) {
+	for _, i := range rand.Perm(256) {
 		ueIPPool.release(ipPoolList[i])
 	}
 
@@ -54,24 +54,24 @@ func TestUeIPPool_ExcludeRange(t *testing.T) {
 		Cidr: "10.10.0.0/24",
 	})
 
-	require.Equal(t, 0x0a0a0001, ueIPPool.pool.Min())
-	require.Equal(t, 0x0a0a00FE, ueIPPool.pool.Max())
-	require.Equal(t, 254, ueIPPool.pool.Remain())
+	require.Equal(t, 0x0a0a0000, ueIPPool.pool.Min())
+	require.Equal(t, 0x0a0a00FF, ueIPPool.pool.Max())
+	require.Equal(t, 256, ueIPPool.pool.Remain())
 
 	excludeUeIPPool := NewUEIPPool(&factory.UEIPPool{
 		Cidr: "10.10.0.0/28",
 	})
 
-	require.Equal(t, 0x0a0a0001, excludeUeIPPool.pool.Min())
-	require.Equal(t, 0x0a0a000E, excludeUeIPPool.pool.Max())
+	require.Equal(t, 0x0a0a0000, excludeUeIPPool.pool.Min())
+	require.Equal(t, 0x0a0a000F, excludeUeIPPool.pool.Max())
 
-	require.Equal(t, 14, excludeUeIPPool.pool.Remain())
+	require.Equal(t, 16, excludeUeIPPool.pool.Remain())
 
 	err := ueIPPool.exclude(excludeUeIPPool)
 	require.NoError(t, err)
-	require.Equal(t, 239, ueIPPool.pool.Remain())
+	require.Equal(t, 240, ueIPPool.pool.Remain())
 
-	for i := 16; i <= 254; i++ {
+	for i := 16; i <= 255; i++ {
 		allocate := ueIPPool.allocate(nil)
 		require.Equal(t, net.ParseIP(fmt.Sprintf("10.10.0.%d", i)).To4(), allocate)
 

--- a/internal/context/user_plane_information.go
+++ b/internal/context/user_plane_information.go
@@ -165,11 +165,13 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 						}
 					}
 					for _, pool := range ueIPPools {
-						if err := pool.pool.Reserve(pool.pool.Min(), pool.pool.Min()); err != nil {
-							logger.InitLog.Errorf("Remove network address failed for %s: %s", pool.ueSubNet.String(), err)
-						}
-						if err := pool.pool.Reserve(pool.pool.Max(), pool.pool.Max()); err != nil {
-							logger.InitLog.Errorf("Remove network address failed for %s: %s", pool.ueSubNet.String(), err)
+						if pool.pool.Min() != pool.pool.Max() {
+							if err := pool.pool.Reserve(pool.pool.Min(), pool.pool.Min()); err != nil {
+								logger.InitLog.Errorf("Remove network address failed for %s: %s", pool.ueSubNet.String(), err)
+							}
+							if err := pool.pool.Reserve(pool.pool.Max(), pool.pool.Max()); err != nil {
+								logger.InitLog.Errorf("Remove network address failed for %s: %s", pool.ueSubNet.String(), err)
+							}
 						}
 						logger.InitLog.Debugf("%d-%s %s %s",
 							snssaiInfo.SNssai.Sst, snssaiInfo.SNssai.Sd,

--- a/internal/context/user_plane_information.go
+++ b/internal/context/user_plane_information.go
@@ -148,17 +148,17 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 							allUEIPPools = append(allUEIPPools, ueIPPool)
 						}
 					}
-					for _, pool := range dnnInfoConfig.StaticPools {
-						ueIPPool := NewUEIPPool(pool)
-						if ueIPPool == nil {
-							logger.InitLog.Fatalf("invalid pools value: %+v", pool)
+					for _, staticPool := range dnnInfoConfig.StaticPools {
+						staticUeIPPool := NewUEIPPool(staticPool)
+						if staticUeIPPool == nil {
+							logger.InitLog.Fatalf("invalid pools value: %+v", staticPool)
 						} else {
-							staticUeIPPools = append(staticUeIPPools, ueIPPool)
+							staticUeIPPools = append(staticUeIPPools, staticUeIPPool)
 							for _, dynamicUePool := range ueIPPools {
-								if dynamicUePool.ueSubNet.Contains(ueIPPool.ueSubNet.IP) {
-									if err := dynamicUePool.exclude(ueIPPool); err != nil {
+								if dynamicUePool.ueSubNet.Contains(staticUeIPPool.ueSubNet.IP) {
+									if err := dynamicUePool.exclude(staticUeIPPool); err != nil {
 										logger.InitLog.Fatalf("exclude static Pool[%s] failed: %v",
-											ueIPPool.ueSubNet, err)
+											staticUeIPPool.ueSubNet, err)
 									}
 								}
 							}

--- a/internal/context/user_plane_information.go
+++ b/internal/context/user_plane_information.go
@@ -164,6 +164,17 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 							}
 						}
 					}
+					for _, pool := range ueIPPools {
+						if err := pool.pool.Reserve(pool.pool.Min(), pool.pool.Min()); err != nil {
+							logger.InitLog.Errorf("Remove network address failed for %s: %s", pool.ueSubNet.String(), err)
+						}
+						if err := pool.pool.Reserve(pool.pool.Max(), pool.pool.Max()); err != nil {
+							logger.InitLog.Errorf("Remove network address failed for %s: %s", pool.ueSubNet.String(), err)
+						}
+						logger.InitLog.Debugf("%d-%s %s %s",
+							snssaiInfo.SNssai.Sst, snssaiInfo.SNssai.Sd,
+							dnnInfoConfig.Dnn, pool.dump())
+					}
 					snssaiInfo.DnnList = append(snssaiInfo.DnnList, &DnnUPFInfoItem{
 						Dnn:             dnnInfoConfig.Dnn,
 						DnaiList:        dnnInfoConfig.DnaiList,


### PR DESCRIPTION
* Fix the behavior when the address range near the boundary is specified in staticPools.
* [SMF] Fix LazyReusePool.Reserve()

Fix for https://github.com/free5gc/free5gc/issues/506.
