### PR TITLE
fix: when staticPool's lower bound equal pools lower bound, it should be legal.

### DIFF
--- a/internal/context/ue_ip_pool.go
+++ b/internal/context/ue_ip_pool.go
@@ -73,7 +73,7 @@ RETURNIP:
 func (ueIPPool *UeIPPool) exclude(excludePool *UeIPPool) error {
 	excludeMin := excludePool.pool.Min()
 	excludeMax := excludePool.pool.Max() + 1
-	if !ueIPPool.ueSubNet.IP.Equal(excludePool.ueSubNet.IP) {
+	if ueIPPool.pool.Min() != excludeMin {
 		excludeMin -= 1
 	}
 	if err := ueIPPool.pool.Reserve(excludeMin, excludeMax); err != nil {


### PR DESCRIPTION
This PR fix the issue: https://github.com/free5gc/free5gc/issues/506

When `staticPools.cidr` is set to **10.60.0.1/32** and `pools.cidr` is **10.60.0.0/16**, it should be legal. 