### PR TITLE
Fix: Raise Error Log when Uplink/Downlink AMBR missing unit

### DIFF
--- a/internal/context/datapath.go
+++ b/internal/context/datapath.go
@@ -444,13 +444,16 @@ func (dataPath *DataPath) ActivateTunnelAndPDR(smContext *SMContext, precedence 
 				logger.PduSessLog.Errorln("new QER failed")
 				return
 			} else {
-				bitRateKbpsULMBR, err := util.BitRateTokbps(sessionRule.AuthSessAmbr.Uplink)
-				if err != nil {
+				var bitRateKbpsULMBR uint64
+				var bitRateKbpsDLMBR uint64
+				var bitRateConvertErr error
+				bitRateKbpsULMBR, bitRateConvertErr = util.BitRateTokbps(sessionRule.AuthSessAmbr.Uplink)
+				if bitRateConvertErr != nil {
 					logger.PduSessLog.Errorln("Cannot get the unit of ULMBR, please check the settings in web console")
 					return
 				}
-				bitRateKbpsDLMBR, err := util.BitRateTokbps(sessionRule.AuthSessAmbr.Downlink)
-				if err != nil {
+				bitRateKbpsDLMBR, bitRateConvertErr = util.BitRateTokbps(sessionRule.AuthSessAmbr.Downlink)
+				if bitRateConvertErr != nil {
 					logger.PduSessLog.Errorln("Cannot get the unit of DLMBR, please check the settings in web console")
 					return
 				}
@@ -859,26 +862,31 @@ func (p *DataPath) AddQoS(smContext *SMContext, qfi uint8, qos *models.QosData) 
 					DLGate: pfcpType.GateOpen,
 				}
 				if isGBRFlow(qos) {
-					bitRateKbpsQoSGBRUL, err := util.BitRateTokbps(qos.GbrUl)
-					if err != nil {
+					var bitRateKbpsQoSGBRUL uint64
+					var bitRateKbpsQoSGBRDL uint64
+					var bitRateKbpsQoSMBRUL uint64
+					var bitRateKbpsQoSMBRDL uint64
+					var bitRateConvertErr error
+					bitRateKbpsQoSGBRUL, bitRateConvertErr = util.BitRateTokbps(qos.GbrUl)
+					if bitRateConvertErr != nil {
 						logger.PduSessLog.Panicln("Cannot get the unit of GBRUL, please check the settings in web console")
 						return
 					}
 
-					bitRateKbpsQoSGBRDL, err := util.BitRateTokbps(qos.GbrDl)
-					if err != nil {
+					bitRateKbpsQoSGBRDL, bitRateConvertErr = util.BitRateTokbps(qos.GbrDl)
+					if bitRateConvertErr != nil {
 						logger.PduSessLog.Panicln("Cannot get the unit of GBRDL, please check the settings in web console")
 						return
 					}
 
-					bitRateKbpsQoSMBRUL, err := util.BitRateTokbps(qos.MaxbrUl)
-					if err != nil {
+					bitRateKbpsQoSMBRUL, bitRateConvertErr = util.BitRateTokbps(qos.MaxbrUl)
+					if bitRateConvertErr != nil {
 						logger.PduSessLog.Panicln("Cannot get the unit of MBRUL, please check the settings in web console")
 						return
 					}
 
-					bitRateKbpsQoSMBRDL, err := util.BitRateTokbps(qos.MaxbrDl)
-					if err != nil {
+					bitRateKbpsQoSMBRDL, bitRateConvertErr = util.BitRateTokbps(qos.MaxbrDl)
+					if bitRateConvertErr != nil {
 						logger.PduSessLog.Panicln("Cannot get the unit of MBRDL, please check the settings in web console")
 						return
 					}
@@ -892,14 +900,17 @@ func (p *DataPath) AddQoS(smContext *SMContext, qfi uint8, qos *models.QosData) 
 						DLMBR: bitRateKbpsQoSMBRDL,
 					}
 				} else {
-					bitRateKbpsSessionAmbrMBRUL, err := util.BitRateTokbps(qos.MaxbrUl)
-					if err != nil {
+					var bitRateKbpsSessionAmbrMBRUL uint64
+					var bitRateKbpsSessionAmbrMBRDL uint64
+					var bitRateConvertErr error
+					bitRateKbpsSessionAmbrMBRUL, bitRateConvertErr = util.BitRateTokbps(qos.MaxbrUl)
+					if bitRateConvertErr != nil {
 						logger.PduSessLog.Error("Cannot get the unit of MBRUL, please check the settings in web console")
 						return
 					}
-					bitRateKbpsSessionAmbrMBRDL, err := util.BitRateTokbps(qos.MaxbrDl)
+					bitRateKbpsSessionAmbrMBRDL, bitRateConvertErr = util.BitRateTokbps(qos.MaxbrDl)
 
-					if err != nil {
+					if bitRateConvertErr != nil {
 						logger.PduSessLog.Error("Cannot get the unit of MBRDL, please check the settings in web console")
 						return
 					}

--- a/internal/util/qos_convert.go
+++ b/internal/util/qos_convert.go
@@ -21,7 +21,7 @@ func BitRateTokbps(bitrate string) (uint64, error) {
 	}
 
 	if len(s) == 1 {
-		return 0, errors.New("cannot get the unit of ULMBR/DLMBR/ULGBR/DLGBR, please check the settings in web console")
+		return uint64(digit * 1000), errors.New("cannot get the unit of ULMBR/DLMBR/ULGBR/DLGBR, we use Mbps for default unit, please check the settings in web console")
 	}
 
 	switch s[1] {

--- a/internal/util/qos_convert.go
+++ b/internal/util/qos_convert.go
@@ -21,7 +21,7 @@ func BitRateTokbps(bitrate string) (uint64, error) {
 	}
 
 	if len(s) == 1 {
-		return uint64(digit * 1000), errors.New("cannot get the unit of ULMBR/DLMBR/ULGBR/DLGBR, we use Mbps for default unit, please check the settings in web console")
+		return 0, errors.New("cannot get the unit of ULMBR/DLMBR/ULGBR/DLGBR, please check the settings in web console")
 	}
 
 	switch s[1] {

--- a/internal/util/qos_convert.go
+++ b/internal/util/qos_convert.go
@@ -1,22 +1,27 @@
 package util
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
 	"github.com/free5gc/ngap/ngapType"
 )
 
-func BitRateTokbps(bitrate string) uint64 {
+func BitRateTokbps(bitrate string) (uint64, error) {
 	s := strings.Split(bitrate, " ")
 	var kbps uint64
 
 	var digit int
 
 	if n, err := strconv.Atoi(s[0]); err != nil {
-		return 0
+		return 0, nil
 	} else {
 		digit = n
+	}
+
+	if len(s) == 1 {
+		return 0, errors.New("cannot get the unit of ULMBR/DLMBR/ULGBR/DLGBR, please check the settings in web console")
 	}
 
 	switch s[1] {
@@ -31,7 +36,7 @@ func BitRateTokbps(bitrate string) uint64 {
 	case "Tbps":
 		kbps = uint64(digit * 1000000000)
 	}
-	return kbps
+	return kbps, nil
 }
 
 func BitRateTombps(bitrate string) uint16 {

--- a/internal/util/qos_convert_test.go
+++ b/internal/util/qos_convert_test.go
@@ -1,4 +1,4 @@
-package qos_convert_test
+package util_test
 
 import (
 	"testing"

--- a/internal/util/tests/qos_convert_test.go
+++ b/internal/util/tests/qos_convert_test.go
@@ -6,9 +6,77 @@ import (
 	"github.com/free5gc/smf/internal/util"
 )
 
-func TestBitRateToKbpsWithValidBitRateShouldReturnValidKbpsBitRate(t *testing.T) {
+func TestBitRateToKbpsWithValidBpsBitRateShouldReturnValidKbpsBitRate(t *testing.T) {
+	var bitrate string = "1000 bps"
+	var correctBitRateKbps uint64 = 1
+
+	bitrateKbps, err := util.BitRateTokbps(bitrate)
+
+	t.Log("Check: err should be nil since act should work correctly.")
+	if err != nil {
+		t.Errorf("Error: err should be nil but it returns %s", err)
+	}
+	t.Log("Check: convert should act correctly.")
+	if bitrateKbps != correctBitRateKbps {
+		t.Errorf("Error: bitrate convert failed. Expect: %d. Actually: %d", correctBitRateKbps, bitrateKbps)
+	}
+	t.Log("Passed.")
+}
+
+func TestBitRateToKbpsWithValidKbpsBitRateShouldReturnValidKbpsBitRate(t *testing.T) {
+	var bitrate string = "1000 Kbps"
+	var correctBitRateKbps uint64 = 1000
+
+	bitrateKbps, err := util.BitRateTokbps(bitrate)
+
+	t.Log("Check: err should be nil since act should work correctly.")
+	if err != nil {
+		t.Errorf("Error: err should be nil but it returns %s", err)
+	}
+	t.Log("Check: convert should act correctly.")
+	if bitrateKbps != correctBitRateKbps {
+		t.Errorf("Error: bitrate convert failed. Expect: %d. Actually: %d", correctBitRateKbps, bitrateKbps)
+	}
+	t.Log("Passed.")
+}
+
+func TestBitRateToKbpsWithValidMbpsBitRateShouldReturnValidKbpsBitRate(t *testing.T) {
 	var bitrate string = "1000 Mbps"
 	var correctBitRateKbps uint64 = 1000000
+
+	bitrateKbps, err := util.BitRateTokbps(bitrate)
+
+	t.Log("Check: err should be nil since act should work correctly.")
+	if err != nil {
+		t.Errorf("Error: err should be nil but it returns %s", err)
+	}
+	t.Log("Check: convert should act correctly.")
+	if bitrateKbps != correctBitRateKbps {
+		t.Errorf("Error: bitrate convert failed. Expect: %d. Actually: %d", correctBitRateKbps, bitrateKbps)
+	}
+	t.Log("Passed.")
+}
+
+func TestBitRateToKbpsWithValidGbpsBitRateShouldReturnValidKbpsBitRate(t *testing.T) {
+	var bitrate string = "1000 Gbps"
+	var correctBitRateKbps uint64 = 1000000000
+
+	bitrateKbps, err := util.BitRateTokbps(bitrate)
+
+	t.Log("Check: err should be nil since act should work correctly.")
+	if err != nil {
+		t.Errorf("Error: err should be nil but it returns %s", err)
+	}
+	t.Log("Check: convert should act correctly.")
+	if bitrateKbps != correctBitRateKbps {
+		t.Errorf("Error: bitrate convert failed. Expect: %d. Actually: %d", correctBitRateKbps, bitrateKbps)
+	}
+	t.Log("Passed.")
+}
+
+func TestBitRateToKbpsWithValidTbpsBitRateShouldReturnValidKbpsBitRate(t *testing.T) {
+	var bitrate string = "1000 Tbps"
+	var correctBitRateKbps uint64 = 1000000000000
 
 	bitrateKbps, err := util.BitRateTokbps(bitrate)
 

--- a/internal/util/tests/qos_convert_test.go
+++ b/internal/util/tests/qos_convert_test.go
@@ -1,0 +1,36 @@
+package qos_convert_test
+
+import (
+	"testing"
+
+	"github.com/free5gc/smf/internal/util"
+)
+
+func TestBitRateToKbpsWithValidBitRateShouldReturnValidKbpsBitRate(t *testing.T) {
+	var bitrate string = "1000 Mbps"
+	var correctBitRateKbps uint64 = 1000000
+
+	bitrateKbps, err := util.BitRateTokbps(bitrate)
+
+	t.Log("Check: err should be nil since act should work correctly.")
+	if err != nil {
+		t.Errorf("Error: err should be nil but it returns %s", err)
+	}
+	t.Log("Check: convert should act correctly.")
+	if bitrateKbps != correctBitRateKbps {
+		t.Errorf("Error: bitrate convert failed. Expect: %d. Actually: %d", correctBitRateKbps, bitrateKbps)
+	}
+	t.Log("Passed.")
+}
+
+func TestBitRateToKbpsWithInvalidBitRateShouldReturnError(t *testing.T) {
+	var bitrate string = "1000" // The unit is absent. It should raise error for `BitRateToKbps`.
+
+	_, err := util.BitRateTokbps(bitrate)
+
+	t.Log("Check: err should not be nil.")
+	if err == nil {
+		t.Error("Error: err should not be nil.")
+	}
+	t.Log("Passed.")
+}


### PR DESCRIPTION
## What's happened?

Hi, I'm Uriah from NYCU Room 215 😄

In this PR, I fix when Uplink/Downlink AMBR in webconsole subscriber page doesn't have unit, it will rasie panic in free5gc SMF.

<img width="715" alt="image" src="https://github.com/user-attachments/assets/25cff179-90de-498f-bde1-72eebf213b02">

In above image, the Uplink/Downlink AMBR doesn't have unit (Mbps or Kbps), it will make free5gc raise panic in below image.

<img width="1164" alt="image" src="https://github.com/user-attachments/assets/30bcac68-8faf-4379-b7e5-04baea2c03bd">

I add error handling in `BitRateTokbps` function and raise Error in `ActivateTunnelAndPDR` function when `BitRateTokbps` function raise the error.

<img width="865" alt="image" src="https://github.com/user-attachments/assets/e9422ed9-ce5c-4e85-9cf8-d51206d782fb">

## Implmentation

 - [x] Add error handling in `ActivateTunnelAndPDR`

## How to review?

 - Check when Uplink/Downlink AMBR doesn't have unit, it should raise error instead of raw panic.