### PR TITLE
fix: Missing ambrQER QFI setting

### DIFF
--- a/internal/context/datapath.go
+++ b/internal/context/datapath.go
@@ -457,6 +457,7 @@ func (dataPath *DataPath) ActivateTunnelAndPDR(smContext *SMContext, precedence 
 					logger.PduSessLog.Errorln("Cannot get the unit of DLMBR, please check the settings in web console")
 					return
 				}
+				newQER.QFI.QFI = sessionRule.DefQosQFI
 				newQER.GateStatus = &pfcpType.GateStatus{
 					ULGate: pfcpType.GateOpen,
 					DLGate: pfcpType.GateOpen,


### PR DESCRIPTION
## Description 

Fix the QFI = 0 in default ambrQER. 

## Screenshot

![image](https://github.com/user-attachments/assets/704b5e00-6f9f-47ed-86df-d1fab4fe4cc2)
