### PR TITLE
fix: make N2 PDUSession release cmd sent under activate state

### DIFF
--- a/internal/sbi/processor/pdu_session.go
+++ b/internal/sbi/processor/pdu_session.go
@@ -379,13 +379,16 @@ func (p *Processor) HandlePDUSessionSMContextUpdate(
 				p.sendGSMPDUSessionReleaseCommand(smContext, buf)
 			}
 
-			if buf, err = smf_context.
-				BuildPDUSessionResourceReleaseCommandTransfer(smContext); err != nil {
-				smContext.Log.Errorf("Build PDUSessionResourceReleaseCommandTransfer failed: %+v", err)
-			} else {
-				response.JsonData.N2SmInfoType = models.N2SmInfoType_PDU_RES_REL_CMD
-				response.BinaryDataN2SmInformation = buf
-				response.JsonData.N2SmInfo = &models.RefToBinaryData{ContentId: "PDUResourceReleaseCommand"}
+			// Only send N2 PDU Session Resource Release when UP connection is active
+			if smContext.UpCnxState == models.UpCnxState_ACTIVATED {
+				if buf, err = smf_context.
+					BuildPDUSessionResourceReleaseCommandTransfer(smContext); err != nil {
+					smContext.Log.Errorf("Build PDUSessionResourceReleaseCommandTransfer failed: %+v", err)
+				} else {
+					response.JsonData.N2SmInfoType = models.N2SmInfoType_PDU_RES_REL_CMD
+					response.BinaryDataN2SmInformation = buf
+					response.JsonData.N2SmInfo = &models.RefToBinaryData{ContentId: "PDUResourceReleaseCommand"}
+				}
 			}
 
 			smContext.SetState(smf_context.PFCPModification)


### PR DESCRIPTION
This fix is related to issue [#630](https://github.com/free5gc/free5gc/issues/630).

I added a status check before sending the N2 PDU Session Resource Release Command.