### PR TITLE
fix: wrong uri format in location header

### DIFF
--- a/internal/sbi/processor/pdu_session.go
+++ b/internal/sbi/processor/pdu_session.go
@@ -264,11 +264,16 @@ func (p *Processor) HandlePDUSessionSMContextCreate(
 		if c.Request.TLS != nil {
 			protocol += "s"
 		}
-		location = fmt.Sprintf("%s://%s%s/%s",
-			protocol,
-			c.Request.Host,
-			strings.TrimSuffix(c.Request.URL.Path, "/"),
-			strings.Split(smContext.Ref, ":")[2])
+		smContextRefParts := strings.Split(smContext.Ref, ":")
+		if len(smContextRefParts) > 2 {
+			location = fmt.Sprintf("%s://%s%s/%s",
+				protocol,
+				c.Request.Host,
+				strings.TrimSuffix(c.Request.URL.Path, "/"),
+				smContextRefParts[2])
+		} else {
+			logger.PduSessLog.Errorln("smContext.Ref(uuid) format is incorrect")
+		}
 	}
 	c.Header("Location", location)
 	c.JSON(http.StatusCreated, response)


### PR DESCRIPTION
This PR fix the problem in issue #71.

Before:
![Screenshot 2025-01-14 at 12 07 19 AM](https://github.com/user-attachments/assets/f357844c-349c-464b-9ffa-9a25930b39b7)

After:
<img width="720" alt="Screenshot 2025-01-14 at 7 26 24 PM" src="https://github.com/user-attachments/assets/d69bfba7-6499-4a8c-bfc1-709338b863f8" />
