### PR TITLE
fix: remove unnecessary qos data record form pcc ruls

### DIFF
--- a/internal/context/sm_context.go
+++ b/internal/context/sm_context.go
@@ -661,8 +661,10 @@ func (c *SMContext) CreatePccRuleDataPath(pccRule *PCCRule,
 		pccRule.Datapath.AddChargingRules(c, chgLevel, chgData)
 	}
 
-	pccRule.Datapath.AddQoS(c, pccRule.QFI, qosData)
-	c.AddQosFlow(pccRule.QFI, qosData)
+	if pccRule.RefQosDataID() != "" {
+		pccRule.Datapath.AddQoS(c, pccRule.QFI, qosData)
+		c.AddQosFlow(pccRule.QFI, qosData)
+	}
 	return nil
 }
 

--- a/internal/context/sm_context_policy.go
+++ b/internal/context/sm_context_policy.go
@@ -163,7 +163,11 @@ func (c *SMContext) ApplyPccRules(
 
 			tgtQosID := tgtPcc.RefQosDataID()
 			_, tgtQosData := c.getSrcTgtQosData(decision.QosDecs, tgtQosID)
-			tgtPcc.SetQFI(c.AssignQFI(tgtQosID))
+
+			// only assign the QFI when there is tgtQoSID (i.e. there is QoSData)
+			if tgtQosID != "" {
+				tgtPcc.SetQFI(c.AssignQFI(tgtQosID))
+			}
 
 			// Create Data path for targetPccRule
 			if err := c.CreatePccRuleDataPath(tgtPcc, tgtTcData, tgtQosData, tgtChgData); err != nil {
@@ -180,11 +184,12 @@ func (c *SMContext) ApplyPccRules(
 			if err := applyFlowInfoOrPFD(tgtPcc); err != nil {
 				return err
 			}
-			finalPccRules[id] = tgtPcc
+
 			if tgtTcID != "" {
 				finalTcDatas[tgtTcID] = tgtTcData
 			}
 			if tgtQosID != "" {
+				finalPccRules[id] = tgtPcc
 				finalQosDatas[tgtQosID] = tgtQosData
 			}
 			if tgtChgID != "" {


### PR DESCRIPTION
This PR addresses issue [#627](https://github.com/free5gc/free5gc/issues/627).

Upon tracing, I found that the default PCC rule created by the PCF contains nil QoS data, which is transformed into a new QoS rule with QFI=2. This is unnecessary and redundant. However, there is two pieces of data required by the SMF: the default charging data. Therefore, it is not necessary to store this default PCC rule in `smContext.PCCRules` after extracting the charging data.

In the original code, if a customized flow rule is set via the web console, two additional QoS flows are added to `smContext.AdditionalQosFlows`. These include one default PCC rule and the customized rule based on the decision made by the PCF. With this update, I discard the default PCC rule and retain only the customized rules. This ensures that the number of `QoSDescriptions` and the items in `QosFlowSetupRequestList` in the NAS packet are accurate.

Changes Made:
- If a PCC rule does not contain a `QoSID` (indicating no QoS data), it will not allocate a QFI to it.
- Only PCC rules with a `QoSID` (indicating QoS data) are stored and appended to `smContext.AdditionalQosFlows` as QoS rules.

I have tested that with this modification, traffic and charging remain functional as before.