### PR TITLE
fix/dl-forwarding-info-not-provision-cause-nil-pointer-panic

### DIFF
--- a/internal/context/ngap_handler.go
+++ b/internal/context/ngap_handler.go
@@ -240,7 +240,8 @@ func HandleHandoverRequestAcknowledgeTransfer(b []byte, ctx *SMContext) error {
 
 	if DLForwardingInfo == nil {
 		ctx.DLForwardingType = NoForwarding
-		return errors.New("DL Forwarding Info not provision")
+		logger.PduSessLog.Warnf("Handle HandoverRequestAcknowledgeTransfer warned: %+v", "DL Forwarding Info not provision")
+		return nil
 	}
 
 	if ctx.DLForwardingType == IndirectForwarding {

--- a/internal/context/ngap_handler.go
+++ b/internal/context/ngap_handler.go
@@ -239,6 +239,7 @@ func HandleHandoverRequestAcknowledgeTransfer(b []byte, ctx *SMContext) error {
 	DLForwardingInfo := handoverRequestAcknowledgeTransfer.DLForwardingUPTNLInformation
 
 	if DLForwardingInfo == nil {
+		ctx.DLForwardingType = NoForwarding
 		return errors.New("DL Forwarding Info not provision")
 	}
 


### PR DESCRIPTION
This PR is related to issue #154.
I've added a type assignment(`NoForwarding`) if detected the "DL Forwarding Info" is not provisioned.