### PR TITLE
fix/duplicate-far-assignment

### DIFF
--- a/internal/pfcp/message/build.go
+++ b/internal/pfcp/message/build.go
@@ -263,6 +263,14 @@ func pdrToUpdatePDR(pdr *context.PDR) *pfcp.UpdatePDR {
 		FarIdValue: pdr.FAR.FARID,
 	}
 
+	for _, qer := range pdr.QER {
+		if qer != nil {
+			updatePDR.QERID = append(updatePDR.QERID, &pfcpType.QERID{
+				QERID: qer.QERID,
+			})
+		}
+	}
+
 	for _, urr := range pdr.URR {
 		if urr != nil {
 			updatePDR.URRID = append(updatePDR.URRID, &pfcpType.URRID{


### PR DESCRIPTION
In update PDR procedure, it really miss the QER parts.
Before:
![v1-without-qer](https://github.com/user-attachments/assets/389da1ae-ce46-4714-8991-9b656f377e30)

After:
![v2-with-qer](https://github.com/user-attachments/assets/4d5c1e74-1a94-4b46-8d02-33a70a121782)
