### PR TITLE
feat: add prometheus metrics support

### DIFF
--- a/internal/sbi/api_pdusession.go
+++ b/internal/sbi/api_pdusession.go
@@ -1,6 +1,7 @@
 package sbi
 
 import (
+	"github.com/free5gc/util/metrics/sbi"
 	"log"
 	"net/http"
 	"strings"
@@ -104,7 +105,9 @@ func (s *Server) HTTPPostSmContexts(c *gin.Context) {
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		logger.PduSessLog.Errorln(problemDetail)
-		c.JSON(http.StatusBadRequest, openapi.ProblemDetailsMalformedReqSyntax(problemDetail))
+		problemDetails := openapi.ProblemDetailsMalformedReqSyntax(problemDetail)
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetails.Status)))
+		c.JSON(int(problemDetails.Status), problemDetails)
 		return
 	}
 

--- a/internal/sbi/api_upi.go
+++ b/internal/sbi/api_upi.go
@@ -1,6 +1,7 @@
 package sbi
 
 import (
+	"github.com/free5gc/util/metrics/sbi"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -63,6 +64,7 @@ func (s *Server) PostUpNodesLinks(c *gin.Context) {
 
 	var json factory.UserPlaneInformation
 	if err := c.ShouldBindJSON(&json); err != nil {
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(http.StatusBadRequest)))
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -82,6 +84,7 @@ func (s *Server) PostUpNodesLinks(c *gin.Context) {
 func (s *Server) DeleteUpNodeLink(c *gin.Context) {
 	// current version does not allow node deletions when ulcl is enabled
 	if smf_context.GetSelf().ULCLSupport {
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(http.StatusForbidden)))
 		c.JSON(http.StatusForbidden, gin.H{})
 	} else {
 		upNodeRef := c.Params.ByName("upNodeRef")
@@ -96,7 +99,9 @@ func (s *Server) DeleteUpNodeLink(c *gin.Context) {
 			upNode.UPF.CancelAssociation()
 			c.JSON(http.StatusOK, gin.H{"status": "OK"})
 		} else {
-			c.JSON(http.StatusNotFound, gin.H{})
+			statusCode := http.StatusNotFound
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(statusCode))
+			c.JSON(statusCode, gin.H{})
 		}
 	}
 }

--- a/internal/sbi/consumer/amf_service.go
+++ b/internal/sbi/consumer/amf_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/free5gc/openapi/amf/Communication"
 	"github.com/free5gc/openapi/models"
+	sbi_metrics "github.com/free5gc/util/metrics/sbi"
 )
 
 type namfService struct {
@@ -30,6 +31,7 @@ func (s *namfService) getCommunicationClient(uri string) *Communication.APIClien
 
 	configuration := Communication.NewConfiguration()
 	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
 	client = Communication.NewAPIClient(configuration)
 
 	s.CommunicationMu.RUnlock()

--- a/internal/sbi/consumer/chf_service.go
+++ b/internal/sbi/consumer/chf_service.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"fmt"
+	sbi_metrics "github.com/free5gc/util/metrics/sbi"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +36,7 @@ func (s *nchfService) getConvergedChargingClient(uri string) *ConvergedCharging.
 
 	configuration := ConvergedCharging.NewConfiguration()
 	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
 	client = ConvergedCharging.NewAPIClient(configuration)
 
 	s.ConvergedChargingMu.RUnlock()

--- a/internal/sbi/consumer/nrf_service.go
+++ b/internal/sbi/consumer/nrf_service.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"context"
 	"fmt"
+	sbi_metrics "github.com/free5gc/util/metrics/sbi"
 	"strings"
 	"sync"
 	"time"
@@ -41,6 +42,7 @@ func (s *nnrfService) getNFManagementClient(uri string) *NFManagement.APIClient 
 
 	configuration := NFManagement.NewConfiguration()
 	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
 	client = NFManagement.NewAPIClient(configuration)
 
 	s.NFManagementgMu.RUnlock()
@@ -63,6 +65,7 @@ func (s *nnrfService) getNFDiscoveryClient(uri string) *NFDiscovery.APIClient {
 
 	configuration := NFDiscovery.NewConfiguration()
 	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
 	client = NFDiscovery.NewAPIClient(configuration)
 
 	s.NFDiscoveryMu.RUnlock()

--- a/internal/sbi/consumer/pcf_service.go
+++ b/internal/sbi/consumer/pcf_service.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"fmt"
+	sbi_metrics "github.com/free5gc/util/metrics/sbi"
 	"net"
 	"regexp"
 	"strconv"
@@ -39,6 +40,7 @@ func (s *npcfService) getSMPolicyControlClient(uri string) *SMPolicyControl.APIC
 
 	configuration := SMPolicyControl.NewConfiguration()
 	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
 	client = SMPolicyControl.NewAPIClient(configuration)
 
 	s.SMPolicyControlMu.RUnlock()

--- a/internal/sbi/consumer/smf_service.go
+++ b/internal/sbi/consumer/smf_service.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	sbi_metrics "github.com/free5gc/util/metrics/sbi"
 	"sync"
 
 	"github.com/free5gc/openapi"
@@ -31,6 +32,7 @@ func (s *nsmfService) getPDUSessionClient(uri string) *PDUSession.APIClient {
 
 	configuration := PDUSession.NewConfiguration()
 	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
 	client = PDUSession.NewAPIClient(configuration)
 
 	s.PDUSessionMu.RUnlock()

--- a/internal/sbi/consumer/udm_service.go
+++ b/internal/sbi/consumer/udm_service.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"context"
 	"fmt"
+	sbi_metrics "github.com/free5gc/util/metrics/sbi"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -39,6 +40,7 @@ func (s *nudmService) getSubscribeDataManagementClient(uri string) *SubscriberDa
 
 	configuration := SubscriberDataManagement.NewConfiguration()
 	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
 	client = SubscriberDataManagement.NewAPIClient(configuration)
 
 	s.SubscriberDataManagementMu.RUnlock()
@@ -61,6 +63,7 @@ func (s *nudmService) getUEContextManagementClient(uri string) *UEContextManagem
 
 	configuration := UEContextManagement.NewConfiguration()
 	configuration.SetBasePath(uri)
+	configuration.SetMetrics(sbi_metrics.SbiMetricHook)
 	client = UEContextManagement.NewAPIClient(configuration)
 
 	s.UEContextManagementMu.RUnlock()

--- a/internal/sbi/processor/notifier.go
+++ b/internal/sbi/processor/notifier.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"fmt"
+	"github.com/free5gc/util/metrics/sbi"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -26,6 +27,7 @@ func (p *Processor) HandleChargingNotification(
 		c.Status(http.StatusNoContent)
 		return
 	}
+	c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 	c.JSON(int(problemDetails.Status), problemDetails)
 }
 

--- a/internal/sbi/processor/oam.go
+++ b/internal/sbi/processor/oam.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"github.com/free5gc/util/metrics/sbi"
 	"net/http"
 	"strconv"
 
@@ -27,7 +28,9 @@ type PDUSessionInfo struct {
 func (p *Processor) HandleOAMGetUEPDUSessionInfo(c *gin.Context, smContextRef string) {
 	smContext := context.GetSMContextByRef(smContextRef)
 	if smContext == nil {
-		c.JSON(http.StatusNotFound, nil)
+		statusCode := http.StatusNotFound
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(statusCode))
+		c.JSON(statusCode, nil)
 		return
 	}
 

--- a/internal/sbi/processor/pdu_session.go
+++ b/internal/sbi/processor/pdu_session.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/free5gc/util/metrics/sbi"
 	"net"
 	"net/http"
 	"reflect"
@@ -44,6 +45,7 @@ func (p *Processor) HandlePDUSessionSMContextCreate(
 				Error: &smf_errors.N1SmError,
 			},
 		}
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, postSmContextsError.JsonData.Error.Cause)
 		c.JSON(http.StatusForbidden, postSmContextsError)
 		return
 	}
@@ -320,6 +322,7 @@ func (p *Processor) HandlePDUSessionSMContextUpdate(
 				},
 			},
 		}
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, updateSmContextError.JsonData.Error.Title)
 		c.JSON(http.StatusNotFound, updateSmContextError)
 		return
 	}
@@ -345,6 +348,7 @@ func (p *Processor) HandlePDUSessionSMContextUpdate(
 					Error: &smf_errors.N1SmError,
 				},
 			} // Depends on the reason why N4 fail
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, updateSmContextError.JsonData.Error.Cause)
 			c.JSON(http.StatusForbidden, updateSmContextError)
 			return
 		}
@@ -844,6 +848,7 @@ func (p *Processor) HandlePDUSessionSMContextUpdate(
 					Error: &smf_errors.N1SmError,
 				},
 			} // Depends on the reason why N4 fail
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, updateSmContextError.JsonData.Error.Cause)
 			c.JSON(http.StatusForbidden, updateSmContextError)
 
 		case smf_context.SessionReleaseSuccess:
@@ -875,6 +880,7 @@ func (p *Processor) HandlePDUSessionSMContextUpdate(
 					errResponse.JsonData.N1SmMsg = &models.RefToBinaryData{ContentId: "PDUSessionReleaseReject"}
 				}
 			}
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, errResponse.JsonData.Error.Cause)
 			c.JSON(int(problemDetail.Status), errResponse)
 		}
 		smContext.PostRemoveDataPath()
@@ -918,6 +924,7 @@ func (p *Processor) HandlePDUSessionSMContextRelease(
 				},
 			},
 		}
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, updateSmContextError.JsonData.Error.Title)
 		c.JSON(http.StatusNotFound, updateSmContextError)
 		return
 	}
@@ -993,6 +1000,7 @@ func (p *Processor) HandlePDUSessionSMContextRelease(
 			errResponse.JsonData.N1SmMsg = &models.RefToBinaryData{ContentId: "PDUSessionReleaseReject"}
 		}
 
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, errResponse.JsonData.Error.Cause)
 		c.JSON(int(problemDetail.Status), errResponse)
 
 	default:
@@ -1015,7 +1023,7 @@ func (p *Processor) HandlePDUSessionSMContextRelease(
 			errResponse.BinaryDataN1SmMessage = buf
 			errResponse.JsonData.N1SmMsg = &models.RefToBinaryData{ContentId: "PDUSessionReleaseReject"}
 		}
-
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, errResponse.JsonData.Error.Cause)
 		c.JSON(int(problemDetail.Status), errResponse)
 	}
 
@@ -1242,12 +1250,15 @@ func (p *Processor) nasErrorResponse(
 			rspBody, contentType, err := openapi.MultipartSerialize(errBody)
 			if err != nil {
 				logger.SBILog.Infof("MultipartSerialize error: %v", err)
-				c.JSON(http.StatusInternalServerError, openapi.ProblemDetailsSystemFailure(err.Error()))
+				problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+				c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+				c.JSON(http.StatusInternalServerError, problemDetails)
 			} else {
 				c.Data(status, contentType, rspBody)
 			}
 			return
 		}
 	}
+	c.Set(sbi.IN_PB_DETAILS_CTX_STR, errBody.JsonData.Error.Cause)
 	c.JSON(status, errBody)
 }

--- a/internal/sbi/server.go
+++ b/internal/sbi/server.go
@@ -3,6 +3,7 @@ package sbi
 import (
 	"context"
 	"fmt"
+	"github.com/free5gc/util/metrics"
 	"net/http"
 	"runtime/debug"
 	"sync"
@@ -67,6 +68,7 @@ func NewServer(smf ServerSmf, tlsKeyLogPath string) (*Server, error) {
 func newRouter(s *Server) *gin.Engine {
 	router := logger_util.NewGinWithLogrus(logger.GinLog)
 
+	router.Use(metrics.InboundMetrics())
 	smfCallbackGroup := router.Group(factory.SmfCallbackUriPrefix)
 	smfCallbackRoutes := s.getCallbackRoutes()
 	applyRoutes(smfCallbackGroup, smfCallbackRoutes)

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -241,7 +241,7 @@ type Metrics struct {
 	Enable      bool   `yaml:"enable" valid:"optional"`
 	Scheme      string `yaml:"scheme" valid:"required,scheme"`
 	BindingIPv4 string `yaml:"bindingIPv4,omitempty" valid:"required,host"` // IP used to run the server in the node.
-	Port        int    `yaml:"port,omitempty" valid:"required,port"`
+	Port        int    `yaml:"port,omitempty" valid:"optional,port"`
 	Tls         *Tls   `yaml:"tls,omitempty" valid:"optional"`
 	Namespace   string `yaml:"namespace" valid:"optional"`
 }

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -7,6 +7,7 @@ package factory
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -27,6 +28,10 @@ const (
 	SmfSbiDefaultIPv4            = "127.0.0.2"
 	SmfSbiDefaultPort            = 8000
 	SmfSbiDefaultScheme          = "https"
+	SmfMetricsDefaultEnabled     = false
+	SmfMetricsDefaultPort        = 9091
+	SmfMetricsDefaultScheme      = "https"
+	SmfMetricsDefaultNamespace   = "free5gc"
 	SmfDefaultNrfUri             = "https://127.0.0.10:8000"
 	SmfEventExposureResUriPrefix = "/nsmf_event-exposure/v1"
 	SmfPdusessionResUriPrefix    = "/nsmf-pdusession/v1"
@@ -46,6 +51,10 @@ type Config struct {
 }
 
 func (c *Config) Validate() (bool, error) {
+	govalidator.TagMap["scheme"] = func(str string) bool {
+		return str == "https" || str == "http"
+	}
+
 	if configuration := c.Configuration; configuration != nil {
 		if result, err := configuration.validate(); err != nil {
 			return result, err
@@ -77,6 +86,7 @@ func (i *Info) validate() (bool, error) {
 type Configuration struct {
 	SmfName              string               `yaml:"smfName" valid:"type(string),required"`
 	Sbi                  *Sbi                 `yaml:"sbi" valid:"required"`
+	Metrics              *Metrics             `yaml:"metrics,omitempty" valid:"optional"`
 	PFCP                 *PFCP                `yaml:"pfcp" valid:"required"`
 	NrfUri               string               `yaml:"nrfUri" valid:"url,required"`
 	NrfCertPem           string               `yaml:"nrfCertPem,omitempty" valid:"optional"`
@@ -104,6 +114,19 @@ func (c *Configuration) validate() (bool, error) {
 	if sbi := c.Sbi; sbi != nil {
 		if result, err := sbi.validate(); err != nil {
 			return result, err
+		}
+	}
+
+	if c.Metrics != nil {
+		if _, err := c.Metrics.validate(); err != nil {
+			return false, err
+		}
+
+		if c.Sbi != nil && c.Metrics.Port == c.Sbi.Port && c.Sbi.BindingIPv4 == c.Metrics.BindingIPv4 {
+			var errs govalidator.Errors
+			err := fmt.Errorf("sbi and metrics bindings IPv4: %s and port: %d cannot be the same, please provide at least another port for the metrics", c.Sbi.BindingIPv4, c.Sbi.Port)
+			errs = append(errs, err)
+			return false, error(errs)
 		}
 	}
 
@@ -212,6 +235,34 @@ func (s *SnssaiDnnInfoItem) validate() (bool, error) {
 
 	result, err := govalidator.ValidateStruct(s)
 	return result, appendInvalid(err)
+}
+
+type Metrics struct {
+	Enable      bool   `yaml:"enable" valid:"optional"`
+	Scheme      string `yaml:"scheme" valid:"required,scheme"`
+	BindingIPv4 string `yaml:"bindingIPv4,omitempty" valid:"required,host"` // IP used to run the server in the node.
+	Port        int    `yaml:"port,omitempty" valid:"required,port"`
+	Tls         *Tls   `yaml:"tls,omitempty" valid:"optional"`
+	Namespace   string `yaml:"namespace" valid:"optional"`
+}
+
+// This function is the mirror of the SBI one, I decided not to factor the code as it could in the future diverge.
+// And it will reduce the cognitive overload when reading the function by not hiding the logic elsewhere.
+func (m *Metrics) validate() (bool, error) {
+	var errs govalidator.Errors
+
+	if tls := m.Tls; tls != nil {
+		if _, err := tls.validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if _, err := govalidator.ValidateStruct(m); err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return false, error(errs)
+	}
+	return true, nil
 }
 
 type Sbi struct {
@@ -784,6 +835,88 @@ func (c *Config) GetLogReportCaller() bool {
 		return false
 	}
 	return c.Logger.ReportCaller
+}
+
+func (c *Config) AreMetricsEnabled() bool {
+	c.RLock()
+	defer c.RUnlock()
+	if c.Configuration != nil && c.Configuration.Metrics != nil {
+		return c.Configuration.Metrics.Enable
+	}
+	return SmfMetricsDefaultEnabled
+}
+
+func (c *Config) GetMetricsScheme() string {
+	c.RLock()
+	defer c.RUnlock()
+	if c.Configuration != nil && c.Configuration.Metrics != nil && c.Configuration.Metrics.Scheme != "" {
+		return c.Configuration.Metrics.Scheme
+	}
+	return SmfMetricsDefaultScheme
+}
+
+func (c *Config) GetMetricsPort() int {
+	c.RLock()
+	defer c.RUnlock()
+	if c.Configuration != nil && c.Configuration.Metrics != nil && c.Configuration.Metrics.Port != 0 {
+		return c.Configuration.Metrics.Port
+	}
+	return SmfMetricsDefaultPort
+}
+
+func (c *Config) GetMetricsBindingIP() string {
+	c.RLock()
+	defer c.RUnlock()
+	bindIP := "0.0.0.0"
+
+	if c.Configuration == nil || c.Configuration.Metrics == nil {
+		return bindIP
+	}
+
+	if c.Configuration.Metrics.BindingIPv4 != "" {
+		if bindIP = os.Getenv(c.Configuration.Metrics.BindingIPv4); bindIP != "" {
+			logger.CfgLog.Infof("Parsing ServerIPv4 [%s] from ENV Variable", bindIP)
+		} else {
+			bindIP = c.Configuration.Metrics.BindingIPv4
+		}
+	}
+	return bindIP
+}
+
+func (c *Config) GetMetricsBindingAddr() string {
+	c.RLock()
+	defer c.RUnlock()
+	return c.GetMetricsBindingIP() + ":" + strconv.Itoa(c.GetMetricsPort())
+}
+
+func (c *Config) GetMetricsCertPemPath() string {
+	// We can see if there is a benefit to factor this tls key/pem with the sbi ones
+	c.RLock()
+	defer c.RUnlock()
+
+	if c.Configuration.Metrics != nil && c.Configuration.Metrics.Tls != nil {
+		return c.Configuration.Metrics.Tls.Pem
+	}
+	return ""
+}
+
+func (c *Config) GetMetricsCertKeyPath() string {
+	c.RLock()
+	defer c.RUnlock()
+
+	if c.Configuration.Metrics != nil && c.Configuration.Metrics.Tls != nil {
+		return c.Configuration.Metrics.Tls.Key
+	}
+	return ""
+}
+
+func (c *Config) GetMetricsNamespace() string {
+	c.RLock()
+	defer c.RUnlock()
+	if c.Configuration.Metrics != nil && c.Configuration.Metrics.Namespace != "" {
+		return c.Configuration.Metrics.Namespace
+	}
+	return SmfMetricsDefaultNamespace
 }
 
 func (c *Config) GetSbiScheme() string {

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -91,7 +91,7 @@ func NewApp(
 	}
 	smf.sbiServer = sbiServer
 
-	features := map[utils.MetricTypeEnabled]bool{}
+	features := map[utils.MetricTypeEnabled]bool{utils.SBI: true}
 	customMetrics := make(map[utils.MetricTypeEnabled][]prometheus.Collector)
 	if cfg.AreMetricsEnabled() {
 		if smf.metricsServer, err = metrics.NewServer(getInitMetrics(cfg, features, customMetrics), tlsKeyLogPath, logger.InitLog); err != nil {

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"github.com/free5gc/util/metrics"
+	"github.com/free5gc/util/metrics/utils"
+	"github.com/prometheus/client_golang/prometheus"
 	"io"
 	"os"
 	"runtime/debug"
@@ -37,10 +40,11 @@ type SmfApp struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	sbiServer *sbi.Server
-	consumer  *consumer.Consumer
-	processor *processor.Processor
-	wg        sync.WaitGroup
+	sbiServer     *sbi.Server
+	metricsServer *metrics.Server
+	consumer      *consumer.Consumer
+	processor     *processor.Processor
+	wg            sync.WaitGroup
 
 	pfcpStart     func(*SmfApp)
 	pfcpTerminate func()
@@ -87,6 +91,14 @@ func NewApp(
 	}
 	smf.sbiServer = sbiServer
 
+	features := map[utils.MetricTypeEnabled]bool{}
+	customMetrics := make(map[utils.MetricTypeEnabled][]prometheus.Collector)
+	if cfg.AreMetricsEnabled() {
+		if smf.metricsServer, err = metrics.NewServer(getInitMetrics(cfg, features, customMetrics), tlsKeyLogPath, logger.InitLog); err != nil {
+			return nil, err
+		}
+	}
+
 	smf.ctx, smf.cancel = context.WithCancel(ctx)
 
 	// for PFCP
@@ -96,6 +108,21 @@ func NewApp(
 	SMF = smf
 
 	return smf, nil
+}
+
+func getInitMetrics(cfg *factory.Config, features map[utils.MetricTypeEnabled]bool, customMetrics map[utils.MetricTypeEnabled][]prometheus.Collector) metrics.InitMetrics {
+	metricsInfo := metrics.Metrics{
+		BindingIPv4: cfg.GetMetricsBindingAddr(),
+		Scheme:      cfg.GetMetricsScheme(),
+		Namespace:   cfg.GetMetricsNamespace(),
+		Port:        cfg.GetMetricsPort(),
+		Tls: metrics.Tls{
+			Key: cfg.GetMetricsCertKeyPath(),
+			Pem: cfg.GetMetricsCertPemPath(),
+		},
+	}
+
+	return metrics.NewInitMetrics(metricsInfo, "smf", features, customMetrics)
 }
 
 func (a *SmfApp) Config() *factory.Config {
@@ -171,6 +198,12 @@ func (a *SmfApp) Start() {
 	a.wg.Add(1)
 	go a.listenShutDownEvent()
 
+	if a.cfg.AreMetricsEnabled() && a.metricsServer != nil {
+		go func() {
+			a.metricsServer.Run(&a.wg)
+		}()
+	}
+
 	// Initialize PFCP server
 	a.pfcpStart(a)
 
@@ -218,6 +251,10 @@ func (a *SmfApp) terminateProcedure() {
 
 	a.sbiServer.Stop()
 	logger.MainLog.Infof("SMF SBI Server terminated")
+	if a.metricsServer != nil {
+		a.metricsServer.Stop()
+		logger.MainLog.Infof("SMF Metrics Server terminated")
+	}
 }
 
 func (a *SmfApp) WaitRoutineStopped() {


### PR DESCRIPTION
This PR introduces Prometheus-compatible metrics to the SMF to support observability and performance monitoring in Free5GC deployments.
#### Key Features

- **SBI Metrics**: Track inbound/outbound HTTP requests on the Service-Based Interface (SBI) with counters and latency histograms.
- **Built-in Metric Server**: Exposes a `/metrics` HTTP endpoint that is configurable and compatible with Prometheus scraping.
- **Modular Design**: Metrics logic is isolated in a dedicated `metrics` package in the `Util` project to minimize code coupling and simplify reuse across NFs.
- **No External Dependencies**: Uses the official Prometheus Go client library only — no sidecars or exporters required.
#### Motivation

Introducing native metrics is a foundational step toward:
- Understanding real-time behavior of the SMF
- Coupled with testing tools such as PacketRusher, it can help with debugging some scenarios.
- Integrating Free5GC into production-grade observability stacks (e.g., Prometheus + Grafana)
#### Configuration

The metrics server is disabled by default. To enable, add the proper section :

```yaml
# Metrics configuration
# If using the same bindingIPv4 as the sbi server, make sure that the ports are different
metrics:
	enable: true # (Optional, default false)
	scheme: http # (Required) the protocol for metrics (http or https, default https)
	bindingIPv4: 127.0.0.18 # (Required) IP used to bind the metrics endpoint (default 0.0.0.0)
	port: 9091 # (Optional, default 9091) port used to bind the service
	tls: # (Optional) the local path of TLS key (Could be the same as the sbi ones)
		pem: /home/sam/private-network/code/free5gc/cert/SMF.pem # SMF TLS Certificate
		key: /home/sam/private-network/code/free5gc/cert/SMF.key # SMF TLS Private key
	namespace: free5gc # (Optional, default free5gc)
```

This new feature needs some changes in the `util` and `openapi` projects , in order to test it you will need to use replace and points to compatible version of these projects while they are not merged yet.

You can use these replaces for simplicity :

```shell
go mod edit -replace github.com/free5gc/openapi=github.com/Niahh/openapi@v0.0.0-20250611124718-fb6f2bd852c3
go mod edit -replace github.com/free5gc/util=github.com/Niahh/free5gc-util@v0.0.0-20250627190743-2d6c16c2b092

go mod tidy
```
#### Backward Compatibility
100% backward compatible – metrics support is optional and deactivated until activated by the user.

#### Integration 
The same metrics architecture is being adapted across other Free5GC NFs (AUSF, NRF, AMF , etc.) to ensure consistency and maintainability.

This work is sponsored by [Free Mobile](https://mobile.free.fr/)!