### PR TITLE
fix: config validate does not always return `govalidator.Errors` type

### DIFF
--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -57,17 +57,26 @@ func InitRoutingConfigFactory(f string, cfg *RoutingConfig) error {
 
 func ReadConfig(cfgPath string) (*Config, error) {
 	cfg := &Config{}
+
 	if err := InitConfigFactory(cfgPath, cfg); err != nil {
 		return nil, fmt.Errorf("ReadConfig [%s] Error: %+v", cfgPath, err)
 	}
+
 	if _, err := cfg.Validate(); err != nil {
-		validErrs := err.(govalidator.Errors).Errors()
-		for _, validErr := range validErrs {
-			logger.CfgLog.Errorf("%+v", validErr)
+		switch e := err.(type) {
+		case govalidator.Errors:
+			validErrs := e.Errors()
+			for _, validErr := range validErrs {
+				logger.CfgLog.Errorf("%+v", validErr)
+			}
+		default:
+			logger.CfgLog.Errorf("%+v", e.Error())
 		}
+
 		logger.CfgLog.Errorf("[-- PLEASE REFER TO SAMPLE CONFIG FILE COMMENTS --]")
 		return nil, fmt.Errorf("Config validate Error")
 	}
+
 
 	return cfg, nil
 }

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -77,7 +77,6 @@ func ReadConfig(cfgPath string) (*Config, error) {
 		return nil, fmt.Errorf("Config validate Error")
 	}
 
-
 	return cfg, nil
 }
 


### PR DESCRIPTION
`Config.Validate()` does not always return error with type `govalidator.Errors`.

## Example

```yaml
# ...

  plmnList:
  - mcc: "208 " # <-- trailing whitespace
    mnc: "93 " # <-- trailing whitespace

#...
```

`Config.Validate()` returns type `*errors.errorString` but `ReadConfig()` crashes because of wrong type assertion in `pkg/factory/factory.go:64`.

## Solution

To fix this problem, I added type switches and remains original behavior with type `govalidator.Errors`. Other type of error, print error message with `Error()` in native `Error` interface.