### PR TITLE
fix: selectAnchorUPF() skip some links when searching

### DIFF
--- a/internal/context/user_plane_information.go
+++ b/internal/context/user_plane_information.go
@@ -810,7 +810,8 @@ func (upi *UserPlaneInformation) selectAnchorUPF(source *UPNode, selection *UPFS
 				if link.MatchedSelection(selectionForIUPF) {
 					queue = append(queue, link)
 					findNewNode = true
-					break
+					// if here we break, we will not check next links
+					// break
 				}
 			}
 		}
@@ -862,6 +863,7 @@ func (upi *UserPlaneInformation) SelectUPFAndAllocUEIP(selection *UPFSelectionPa
 		return nil, nil, false
 	}
 	UPFList := upi.selectAnchorUPF(source, selection)
+	logger.CtxLog.Debug("UPFList: ", UPFList)
 	listLength := len(UPFList)
 	if listLength == 0 {
 		logger.CtxLog.Warnf("Can't find UPF with DNN[%s] S-NSSAI[sst: %d sd: %s] DNAI[%s]\n", selection.Dnn,


### PR DESCRIPTION
## Description

selectAnchorUPF() should perform a BFS over the topology defined in smfcfg.yaml for all UPF nodes and return a list of qualified UPFs.

In the previous implementation, it stopped upon finding the first new UPF node, ignoring other links.

Test case: 

```yaml
 # the topology graph of userplane, A and B represent the two nodes of each link
links:
      - A: gNB1
        B: UPF1
      - A: gNB1
        B: UPF2
      - A: gNB1
        B: UPF3

```