### PR TITLE
fix: correct ApiFullVersion and Scheme in NRF registration

### DIFF
--- a/internal/context/nf_profile.go
+++ b/internal/context/nf_profile.go
@@ -23,8 +23,7 @@ func (c *SMFContext) SetupNFProfile(nfProfileconfig *factory.Config) {
 	c.NfProfile.NFServiceVersion = &[]models.NfServiceVersion{
 		{
 			ApiVersionInUri: "v1",
-			ApiFullVersion: fmt.
-				Sprintf("https://%s:%d"+factory.SmfPdusessionResUriPrefix, GetSelf().RegisterIPv4, GetSelf().SBIPort),
+			ApiFullVersion: nfProfileconfig.GetVersion(),
 			Expiry: &nfSetupTime,
 		},
 	}
@@ -36,7 +35,7 @@ func (c *SMFContext) SetupNFProfile(nfProfileconfig *factory.Config) {
 			ServiceInstanceId: GetSelf().NfInstanceID + serviceName,
 			ServiceName:       models.ServiceName(serviceName),
 			Versions:          *c.NfProfile.NFServiceVersion,
-			Scheme:            models.UriScheme_HTTPS,
+			Scheme:            GetSelf().URIScheme,
 			NfServiceStatus:   models.NfServiceStatus_REGISTERED,
 			ApiPrefix:         fmt.Sprintf("%s://%s:%d", GetSelf().URIScheme, GetSelf().RegisterIPv4, GetSelf().SBIPort),
 			IpEndPoints: []models.IpEndPoint{

--- a/internal/context/nf_profile.go
+++ b/internal/context/nf_profile.go
@@ -23,8 +23,8 @@ func (c *SMFContext) SetupNFProfile(nfProfileconfig *factory.Config) {
 	c.NfProfile.NFServiceVersion = &[]models.NfServiceVersion{
 		{
 			ApiVersionInUri: "v1",
-			ApiFullVersion: nfProfileconfig.GetVersion(),
-			Expiry: &nfSetupTime,
+			ApiFullVersion:  nfProfileconfig.GetVersion(),
+			Expiry:          &nfSetupTime,
 		},
 	}
 


### PR DESCRIPTION
## Problem

Two bugs in `SetupNFProfile()` caused NRF registration to fail with HTTP 400
when registering against strict NRF implementations (e.g. Oracle NRF).

### 1. ApiFullVersion contains a URL instead of a version string

`ApiFullVersion` was set to the full PDU session endpoint URL:
https://<ip>:<port>/nsmf-pdusession/v1


According to 3GPP TS 29.510, `ApiFullVersion` must be a version string
(e.g. `"1.0.7"`), not a URL. The URL belongs in `ApiPrefix`.

### 2. Scheme hardcoded to HTTPS

`Scheme` was hardcoded to `models.UriScheme_HTTPS` regardless of the
configured `sbi.scheme` in `smfcfg.yaml`. This caused a mismatch with
`ApiPrefix` which already correctly used `GetSelf().URIScheme`, leading
NRF to reject the registration.

## Fix

- `ApiFullVersion`: use `nfProfileconfig.GetVersion()` to read the version
  string from config (`info.version` in `smfcfg.yaml`)
- `Scheme`: use `GetSelf().URIScheme` to dynamically reflect the configured
  SBI scheme, consistent with `ApiPrefix`

## Testing

Verified SMF successfully registers with Vendor NRF after this fix.