### PR TITLE
fix(notifier): add OAuth2 token to namf-callback and nnef-callback outbound calls; add nsmf-callback inbound auth

### DIFF
--- a/internal/sbi/consumer/chf_service.go
+++ b/internal/sbi/consumer/chf_service.go
@@ -92,7 +92,7 @@ func (s *nchfService) buildConvergedChargingRequest(smContext *smf_context.SMCon
 				DnnId: smContext.Dnn,
 			},
 		},
-		NotifyUri: fmt.Sprintf("%s://%s:%d/nsmf-callback/notify_%s",
+		NotifyUri: fmt.Sprintf("%s://%s:%d/nsmf-callback/v1/notify_%s",
 			smfContext.URIScheme,
 			smfContext.RegisterIPv4,
 			smfContext.SBIPort,

--- a/internal/sbi/consumer/pcf_service.go
+++ b/internal/sbi/consumer/pcf_service.go
@@ -71,7 +71,7 @@ func (s *npcfService) SendSMPolicyAssociationCreate(smContext *smf_context.SMCon
 
 	smPolicyData.Supi = smContext.Supi
 	smPolicyData.PduSessionId = smContext.PDUSessionID
-	smPolicyData.NotificationUri = fmt.Sprintf("%s://%s:%d/nsmf-callback/sm-policies/%s",
+	smPolicyData.NotificationUri = fmt.Sprintf("%s://%s:%d/nsmf-callback/v1/sm-policies/%s",
 		smf_context.GetSelf().URIScheme,
 		smf_context.GetSelf().RegisterIPv4,
 		smf_context.GetSelf().SBIPort,

--- a/internal/sbi/consumer/smf_service.go
+++ b/internal/sbi/consumer/smf_service.go
@@ -1,12 +1,12 @@
 package consumer
 
 import (
-	"context"
 	"sync"
 
 	"github.com/free5gc/openapi"
 	"github.com/free5gc/openapi/models"
 	"github.com/free5gc/openapi/smf/PDUSession"
+	smf_context "github.com/free5gc/smf/internal/context"
 	"github.com/free5gc/smf/internal/logger"
 	sbi_metrics "github.com/free5gc/util/metrics/sbi"
 )
@@ -54,9 +54,16 @@ func (s *nsmfService) SendSMContextStatusNotification(uri string) (*models.Probl
 
 		client := s.getPDUSessionClient(uri)
 
+		ctx, pd, err := smf_context.GetSelf().GetTokenCtx(
+			models.ServiceName("namf-callback"), models.NrfNfManagementNfType_AMF)
+		if err != nil {
+			logger.CtxLog.Warnf("[SMF] Get token for AMF callback failed: %+v", pd)
+			return pd, err
+		}
+
 		logger.CtxLog.Infoln("[SMF] Send SMContext Status Notification")
 		_, localErr := client.SMContextsCollectionApi.
-			PostSmContextsSmContextStatusNotificationPost(context.Background(), uri, request)
+			PostSmContextsSmContextStatusNotificationPost(ctx, uri, request)
 
 		switch err := localErr.(type) {
 		case openapi.GenericOpenAPIError:

--- a/internal/sbi/processor/notifier.go
+++ b/internal/sbi/processor/notifier.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -132,9 +131,17 @@ func SendUpPathChgEventExposureNotification(
 	request := &EventExposure.CreateIndividualSubcriptionMyNotificationPostRequest{
 		NsmfEventExposureNotification: notification,
 	}
-	_, err := client.
+
+	ctx, pd, err := smf_context.GetSelf().GetTokenCtx(
+		models.ServiceName("nnef-callback"), models.NrfNfManagementNfType_NEF)
+	if err != nil {
+		logger.PduSessLog.Warnf("SMF Event Exposure Notification get token failed: %+v", pd)
+		return
+	}
+
+	_, err = client.
 		SubscriptionsCollectionApi.
-		CreateIndividualSubcriptionMyNotificationPost(context.Background(), uri, request)
+		CreateIndividualSubcriptionMyNotificationPost(ctx, uri, request)
 
 	switch err := err.(type) {
 	case openapi.GenericOpenAPIError:

--- a/internal/sbi/server.go
+++ b/internal/sbi/server.go
@@ -71,6 +71,10 @@ func newRouter(s *Server) *gin.Engine {
 	router.Use(metrics.InboundMetrics())
 	smfCallbackGroup := router.Group(factory.SmfCallbackUriPrefix)
 	smfCallbackRoutes := s.getCallbackRoutes()
+	smfCallbackAuthCheck := util_oauth.NewRouterAuthorizationCheck(models.ServiceName("nsmf-callback"))
+	smfCallbackGroup.Use(func(c *gin.Context) {
+		smfCallbackAuthCheck.Check(c, smf_context.GetSelf())
+	})
 	applyRoutes(smfCallbackGroup, smfCallbackRoutes)
 
 	upiGroup := router.Group(factory.UpiUriPrefix)

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -38,7 +38,7 @@ const (
 	SmfEventExposureResUriPrefix = "/nsmf_event-exposure/v1"
 	SmfPdusessionResUriPrefix    = "/nsmf-pdusession/v1"
 	SmfOamUriPrefix              = "/nsmf-oam/v1"
-	SmfCallbackUriPrefix         = "/nsmf-callback"
+	SmfCallbackUriPrefix         = "/nsmf-callback/v1"
 	NrfDiscUriPrefix             = "/nnrf-disc/v1"
 	UdmSdmUriPrefix              = "/nudm-sdm/v1"
 	PcfSmpolicycontrolUriPrefix  = "/npcf-smpolicycontrol/v1"
@@ -155,9 +155,10 @@ func (c *Configuration) validate() (bool, error) {
 		case "nsmf-pdusession":
 		case "nsmf-event-exposure":
 		case "nsmf-oam":
+		case "nsmf-callback":
 		default:
 			err := errors.New("invalid serviceNameList[" + strconv.Itoa(index) + "]: " +
-				serviceName + ", should be nsmf-pdusession, nsmf-event-exposure or nsmf-oam")
+				serviceName + ", should be nsmf-pdusession, nsmf-event-exposure, nsmf-oam or nsmf-callback")
 			return false, err
 		}
 	}


### PR DESCRIPTION
**Problem**
- SMF sent `namf-callback` (status notification to AMF) and `nnef-callback` (event exposure notification to NEF) using `context.Background()`, bypassing OAuth2. Receiving NFs rejected with 401.
- SMF's own `nsmf-callback` route had no inbound OAuth2 verification.

**Changes**
- `consumer/smf_service.go`: replace `context.Background()` with `GetTokenCtx("namf-callback", AMF)` for SMF→AMF status notify
- `processor/notifier.go`: replace `context.Background()` with `GetTokenCtx("nnef-callback", NEF)` for SMF→NEF event exposure notify
- `server.go`: add `RouterAuthorizationCheck` middleware to `nsmf-callback` route group