### PR TITLE
feat: include UE location info in SM Policy Association Create request

### DIFF
--- a/internal/sbi/consumer/pcf_service.go
+++ b/internal/sbi/consumer/pcf_service.go
@@ -90,6 +90,15 @@ func (s *npcfService) SendSMPolicyAssociationCreate(smContext *smf_context.SMCon
 		Mnc: smContext.ServingNetwork.Mnc,
 	}
 	smPolicyData.SuppFeat = "F"
+	if smContext.UeLocation != nil {
+		ueLocation := *smContext.UeLocation
+		if ueLocation.NrLocation != nil && ueLocation.NrLocation.AgeOfLocationInformation < 0 {
+			nrLoc := *ueLocation.NrLocation
+			nrLoc.AgeOfLocationInformation = 0
+			ueLocation.NrLocation = &nrLoc
+		}
+		smPolicyData.UserLocationInfo = &ueLocation
+	}
 
 	ctx, _, err := smf_context.GetSelf().
 		GetTokenCtx(models.ServiceName_NPCF_SMPOLICYCONTROL, models.NrfNfManagementNfType_PCF)


### PR DESCRIPTION
## Problem

When SMF sends the `SmPolicyContextData` to PCF during SM Policy
Association Create (3GPP TS 29.512, N7 interface), the
`userLocationInfo` field was not populated. This prevents the PCF from
applying location-based policies at session establishment.

## Solution

Populate `UserLocationInfo` from `smContext.UeLocation` when available.

A sanitization guard is also added: if `NrLocation.AgeOfLocationInformation`
is negative (Go zero-value default when the field was not set by the
RAN), it is clamped to `0` to avoid sending an invalid value to the PCF.

## Changes

- `internal/sbi/consumer/pcf_service.go`: set `smPolicyData.UserLocationInfo`
  in `SendSMPolicyAssociationCreate`

## Related spec

- 3GPP TS 29.512 §4.2.2.2 — `SmPolicyContextData` / `userLocationInfo`

## Verification

Captured N7 `POST /npcf-smpolicycontrol/v1/sm-policies` request body
confirms `userLocationInfo` is now included:

```json
{
    "supi": "imsi-208930000000001",
    "pduSessionId": 1,
    "userLocationInfo": {
        "nrLocation": {
            "ncgi": {
                "nrCellId": "000000010",
                "plmnId": { "mcc": "208", "mnc": "93" }
            },
            "tai": {
                "plmnId": { "mcc": "208", "mnc": "93" },
                "tac": "000001"
            },
            "ueLocationTimestamp": "2026-03-24T12:21:39.658042574Z"
        }
    },
    ...
}
```