### PR TITLE
fix: notify PCF with AN_CH_COR trigger after N2 handover completes

### DIFF
--- a/internal/sbi/consumer/pcf_service.go
+++ b/internal/sbi/consumer/pcf_service.go
@@ -90,6 +90,15 @@ func (s *npcfService) SendSMPolicyAssociationCreate(smContext *smf_context.SMCon
 		Mnc: smContext.ServingNetwork.Mnc,
 	}
 	smPolicyData.SuppFeat = "F"
+	if smContext.UeLocation != nil {
+		ueLocation := *smContext.UeLocation
+		if ueLocation.NrLocation != nil && ueLocation.NrLocation.AgeOfLocationInformation < 0 {
+			nrLoc := *ueLocation.NrLocation
+			nrLoc.AgeOfLocationInformation = 0
+			ueLocation.NrLocation = &nrLoc
+		}
+		smPolicyData.UserLocationInfo = &ueLocation
+	}
 
 	ctx, _, err := smf_context.GetSelf().
 		GetTokenCtx(models.ServiceName_NPCF_SMPOLICYCONTROL, models.NrfNfManagementNfType_PCF)
@@ -422,6 +431,42 @@ func (s *npcfService) buildPktFilterInfo(pf nasType.PacketFilter) (*models.Packe
 	}
 	// according TS 29.212 IPFilterRule cannot use [options]
 	return pfInfo, nil
+}
+
+func (s *npcfService) SendSMPolicyAssociationUpdateByLocationChange(
+	smContext *smf_context.SMContext,
+) (*models.SmPolicyDecision, error) {
+	updateSMPolicy := models.SmPolicyUpdateContextData{
+		RepPolicyCtrlReqTriggers: []models.PolicyControlRequestTrigger{
+			models.PolicyControlRequestTrigger_AN_CH_COR,
+		},
+		UserLocationInfo: smContext.UeLocation,
+	}
+
+	ctx, _, err := smf_context.GetSelf().
+		GetTokenCtx(models.ServiceName_NPCF_SMPOLICYCONTROL, models.NrfNfManagementNfType_PCF)
+	if err != nil {
+		return nil, err
+	}
+
+	var client *SMPolicyControl.APIClient
+	for _, service := range smContext.SelectedPCFProfile.NfServices {
+		if service.ServiceName == models.ServiceName_NPCF_SMPOLICYCONTROL {
+			client = s.getSMPolicyControlClient(service.ApiPrefix)
+		}
+	}
+
+	request := &SMPolicyControl.UpdateSMPolicyRequest{
+		SmPolicyId:                &smContext.SMPolicyID,
+		SmPolicyUpdateContextData: &updateSMPolicy,
+	}
+
+	smPolicyDecisionFromPCF, err := client.IndividualSMPolicyDocumentApi.UpdateSMPolicy(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("update sm policy [%s] by location change failed: %s", smContext.SMPolicyID, err)
+	}
+	smPolicyDecision := smPolicyDecisionFromPCF.SmPolicyDecision
+	return &smPolicyDecision, nil
 }
 
 func (s *npcfService) SendSMPolicyAssociationTermination(smContext *smf_context.SMContext) error {

--- a/internal/sbi/processor/pdu_session.go
+++ b/internal/sbi/processor/pdu_session.go
@@ -1025,6 +1025,9 @@ func (p *Processor) HandlePDUSessionSMContextUpdate(
 			farList = append(farList, indirectForwardingPDR.FAR)
 		}
 
+		if smContextUpdateData.UeLocation != nil {
+			smContext.UeLocation = smContextUpdateData.UeLocation
+		}
 		sendPFCPModification = true
 		smContext.SetState(smf_context.PFCPModification)
 		smContext.HoState = models.HoState_COMPLETED
@@ -1076,6 +1079,24 @@ func (p *Processor) HandlePDUSessionSMContextUpdate(
 		case smf_context.SessionUpdateSuccess:
 			smContext.Log.Traceln("In case SessionUpdateSuccess")
 			smContext.SetState(smf_context.Active)
+			if smContext.HoState == models.HoState_COMPLETED && smContext.UeLocation != nil {
+				go func() {
+					if smPolicyDecision, err := p.Consumer().SendSMPolicyAssociationUpdateByLocationChange(smContext); err != nil {
+						smContext.Log.Warnf("SendSMPolicyAssociationUpdateByLocationChange failed: %s", err)
+					} else if smPolicyDecision != nil {
+						smContext.SMLock.Lock()
+						defer smContext.SMLock.Unlock()
+						if err := smContext.ApplySessionRules(smPolicyDecision); err != nil {
+							smContext.Log.Errorf("apply session rules after handover failed: %v", err)
+						}
+						if err := smContext.ApplyPccRules(smPolicyDecision); err != nil {
+							smContext.Log.Errorf("apply pcc rules after handover failed: %v", err)
+						}
+						ActivateUPFSession(smContext, nil)
+						smContext.PostRemoveDataPath()
+					}
+				}()
+			}
 			c.Render(http.StatusOK, openapi.MultipartRelatedRender{Data: response})
 		case smf_context.SessionUpdateFailed:
 			smContext.Log.Traceln("In case SessionUpdateFailed")


### PR DESCRIPTION
## Summary

After N2 handover completes, SMF now reports the UE's new location to
PCF using the `AN_CH_COR` (Access Network Change Correlation) trigger,
as required by 3GPP TS 29.512 §5.6.3.

## Changes

### `internal/sbi/consumer/pcf_service.go`
Added `SendSMPolicyAssociationUpdateByLocationChange()` which sends
`SmPolicyUpdateContextData` with:
- `repPolicyCtrlReqTriggers: [AN_CH_COR]`
- `userLocationInfo`: UE's post-handover location

### `internal/sbi/processor/pdu_session.go`
1. In `HoState_COMPLETED` handler: save `ueLocation` from AMF request
   into `smContext.UeLocation`
2. In `SessionUpdateSuccess` (after PFCP path-switch): launch async
   goroutine to notify PCF and apply returned policy decision via PFCP

The goroutine is async to avoid blocking the 200 OK to AMF — a sync
call would delay `UEContextReleaseCommand` to the source gNB and cause
DL traffic outage of ~3 minutes in testing.

## Related PR
Requires AMF change to populate `ueLocation` in HoState=COMPLETED:
free5gc/amf#204

## Testing
Verified with free5gc v4.2.0 + UERANSIM + OAI rfsim + vendor PCF
- SMF correctly stores post-handover UE location from AMF
- PCF notified with AN_CH_COR + userLocationInfo after path-switch
- PCF-returned AMBR update applied to UPF via second PFCP modification
- First PFCP (path-switch) remains synchronous per TS 23.502 §4.9.1.3