### PR TITLE
Handle and propagate SM Context initialization errors

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -120,10 +120,9 @@ func AllocateLocalSEID() uint64 {
 	return atomic.AddUint64(&smfContext.LocalSEIDCount, 1)
 }
 
-func InitSmfContext(config *factory.Config) {
+func InitSmfContext(config *factory.Config) error {
 	if config == nil {
-		logger.CtxLog.Error("Config is nil")
-		return
+		return fmt.Errorf("config is nil")
 	}
 
 	logger.CtxLog.Infof("smfconfig Info: Version[%s] Description[%s]", config.Info.Version, config.Info.Description)
@@ -134,8 +133,7 @@ func InitSmfContext(config *factory.Config) {
 
 	sbi := configuration.Sbi
 	if sbi == nil {
-		logger.CtxLog.Errorln("Configuration needs \"sbi\" value")
-		return
+		return fmt.Errorf("configuration needs \"sbi\" value")
 	} else {
 		smfContext.URIScheme = models.UriScheme(sbi.Scheme)
 		smfContext.RegisterIPv4 = factory.SmfSbiDefaultIPv4 // default localhost
@@ -239,7 +237,11 @@ func InitSmfContext(config *factory.Config) {
 
 	smfContext.SupportedPDUSessionType = "IPv4"
 
-	smfContext.UserPlaneInformation = NewUserPlaneInformation(&configuration.UserPlaneInformation)
+	userPlaneInformation, err := NewUserPlaneInformation(&configuration.UserPlaneInformation)
+	if err != nil {
+		return fmt.Errorf("initialize user plane information failed: %w", err)
+	}
+	smfContext.UserPlaneInformation = userPlaneInformation
 
 	smfContext.ChargingIDGenerator = idgenerator.NewGenerator(1, math.MaxUint32)
 
@@ -250,6 +252,8 @@ func InitSmfContext(config *factory.Config) {
 	TeidGenerator = idgenerator.NewGenerator(1, math.MaxUint32)
 
 	smfContext.Ues = InitSmfUeData()
+
+	return nil
 }
 
 func InitSMFUERouting(routingConfig *factory.RoutingConfig) {

--- a/internal/context/sm_context_policy_test.go
+++ b/internal/context/sm_context_policy_test.go
@@ -111,7 +111,9 @@ var testConfig = factory.Config{
 }
 
 func initConfig() {
-	smf_context.InitSmfContext(&testConfig)
+	if err := smf_context.InitSmfContext(&testConfig); err != nil {
+		panic(err)
+	}
 	factory.SmfConfig = &testConfig
 }
 

--- a/internal/context/sm_context_policy_test.go
+++ b/internal/context/sm_context_policy_test.go
@@ -623,7 +623,9 @@ func TestApplyPccRules(t *testing.T) {
 	}
 
 	smfContext := smf_context.GetSelf()
-	smfContext.UserPlaneInformation = smf_context.NewUserPlaneInformation(&userPlaneConfig)
+	userPlaneInformation, err := smf_context.NewUserPlaneInformation(&userPlaneConfig)
+	require.NoError(t, err)
+	smfContext.UserPlaneInformation = userPlaneInformation
 	for _, n := range smfContext.UserPlaneInformation.UPFs {
 		n.UPF.AssociationContext = context.Background()
 	}
@@ -681,7 +683,7 @@ func TestApplyPccRules(t *testing.T) {
 			Downlink: "1 Gbps",
 		},
 	}
-	err := smctx.AllocUeIP()
+	err = smctx.AllocUeIP()
 	require.NoError(t, err)
 	err = smctx.SelectDefaultDataPath()
 	require.NoError(t, err)

--- a/internal/context/ue_datapath_test.go
+++ b/internal/context/ue_datapath_test.go
@@ -152,8 +152,8 @@ func TestNewUEPreConfigPaths(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			retUePreConfigPaths, err := context.NewUEPreConfigPaths(tc.inPaths)
-			require.Nil(t, err)
+			retUePreConfigPaths, preConfigErr := context.NewUEPreConfigPaths(tc.inPaths)
+			require.Nil(t, preConfigErr)
 			require.NotNil(t, retUePreConfigPaths.PathIDGenerator)
 			for pathIndex, path := range tc.inPaths {
 				retDataPath := retUePreConfigPaths.DataPathPool[int64(pathIndex+1)]

--- a/internal/context/ue_datapath_test.go
+++ b/internal/context/ue_datapath_test.go
@@ -16,7 +16,9 @@ var config = configuration
 
 func TestNewUEPreConfigPaths(t *testing.T) {
 	smfContext := context.GetSelf()
-	smfContext.UserPlaneInformation = context.NewUserPlaneInformation(config)
+	userPlaneInformation, err := context.NewUserPlaneInformation(config)
+	require.NoError(t, err)
+	smfContext.UserPlaneInformation = userPlaneInformation
 	fmt.Println("Start")
 	testcases := []struct {
 		name                  string

--- a/internal/context/user_plane_information.go
+++ b/internal/context/user_plane_information.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"net"
 	"reflect"
@@ -80,7 +81,7 @@ func AllocateUPFID() {
 }
 
 // NewUserPlaneInformation process the configuration then returns a new instance of UserPlaneInformation
-func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlaneInformation {
+func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) (*UserPlaneInformation, error) {
 	nodePool := make(map[string]*UPNode)
 	upfPool := make(map[string]*UPNode)
 	anPool := make(map[string]*UPNode)
@@ -142,7 +143,7 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 					for _, pool := range dnnInfoConfig.Pools {
 						ueIPPool := NewUEIPPool(pool)
 						if ueIPPool == nil {
-							logger.InitLog.Fatalf("invalid pools value: %+v", pool)
+							return nil, fmt.Errorf("invalid pools value: %+v", pool)
 						} else {
 							ueIPPools = append(ueIPPools, ueIPPool)
 							allUEIPPools = append(allUEIPPools, ueIPPool)
@@ -151,13 +152,13 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 					for _, staticPool := range dnnInfoConfig.StaticPools {
 						staticUeIPPool := NewUEIPPool(staticPool)
 						if staticUeIPPool == nil {
-							logger.InitLog.Fatalf("invalid pools value: %+v", staticPool)
+							return nil, fmt.Errorf("invalid pools value: %+v", staticPool)
 						} else {
 							staticUeIPPools = append(staticUeIPPools, staticUeIPPool)
 							for _, dynamicUePool := range ueIPPools {
 								if dynamicUePool.ueSubNet.Contains(staticUeIPPool.ueSubNet.IP) {
 									if err := dynamicUePool.Exclude(staticUeIPPool); err != nil {
-										logger.InitLog.Fatalf("exclude static Pool[%s] failed: %v",
+										return nil, fmt.Errorf("exclude static Pool[%s] failed: %v",
 											staticUeIPPool.ueSubNet, err)
 									}
 								}
@@ -200,7 +201,7 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 	}
 
 	if isOverlap(allUEIPPools) {
-		logger.InitLog.Fatalf("overlap cidr value between UPFs")
+		return nil, fmt.Errorf("overlap cidr value between UPFs")
 	}
 
 	for _, link := range upTopology.Links {
@@ -229,7 +230,7 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 		DefaultUserPlanePathToUPF: make(map[string]map[string][]*UPNode),
 	}
 
-	return userplaneInformation
+	return userplaneInformation, nil
 }
 
 func (upi *UserPlaneInformation) UpNodesToConfiguration() map[string]*factory.UPNode {
@@ -358,7 +359,7 @@ func (upi *UserPlaneInformation) LinksToConfiguration() []*factory.UPLink {
 	return links
 }
 
-func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.UserPlaneInformation) {
+func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.UserPlaneInformation) error {
 	for name, node := range upTopology.UPNodes {
 		if _, ok := upi.UPNodes[name]; ok {
 			logger.InitLog.Warningf("Node [%s] already exists in SMF.\n", name)
@@ -413,7 +414,7 @@ func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.Us
 					for _, pool := range dnnInfoConfig.Pools {
 						ueIPPool := NewUEIPPool(pool)
 						if ueIPPool == nil {
-							logger.InitLog.Fatalf("invalid pools value: %+v", pool)
+							return fmt.Errorf("invalid pools value: %+v", pool)
 						} else {
 							ueIPPools = append(ueIPPools, ueIPPool)
 						}
@@ -421,13 +422,13 @@ func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.Us
 					for _, pool := range dnnInfoConfig.StaticPools {
 						ueIPPool := NewUEIPPool(pool)
 						if ueIPPool == nil {
-							logger.InitLog.Fatalf("invalid pools value: %+v", pool)
+							return fmt.Errorf("invalid pools value: %+v", pool)
 						} else {
 							staticUeIPPools = append(staticUeIPPools, ueIPPool)
 							for _, dynamicUePool := range ueIPPools {
 								if dynamicUePool.ueSubNet.Contains(ueIPPool.ueSubNet.IP) {
 									if err := dynamicUePool.Exclude(ueIPPool); err != nil {
-										logger.InitLog.Fatalf("exclude static Pool[%s] failed: %v",
+										return fmt.Errorf("exclude static Pool[%s] failed: %v",
 											ueIPPool.ueSubNet, err)
 									}
 								}
@@ -476,8 +477,10 @@ func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.Us
 		}
 	}
 	if isOverlap(allUEIPPools) {
-		logger.InitLog.Fatalf("overlap cidr value between UPFs")
+		return fmt.Errorf("overlap cidr value between UPFs")
 	}
+
+	return nil
 }
 
 func (upi *UserPlaneInformation) LinksFromConfiguration(upTopology *factory.UserPlaneInformation) {

--- a/internal/context/user_plane_information.go
+++ b/internal/context/user_plane_information.go
@@ -360,12 +360,50 @@ func (upi *UserPlaneInformation) LinksToConfiguration() []*factory.UPLink {
 }
 
 func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.UserPlaneInformation) error {
+	candidateUPNodes := make(map[string]*UPNode, len(upi.UPNodes))
+	for name, node := range upi.UPNodes {
+		candidateUPNodes[name] = node
+	}
+
+	candidateUPFs := make(map[string]*UPNode, len(upi.UPFs))
+	for name, node := range upi.UPFs {
+		candidateUPFs[name] = node
+	}
+
+	candidateAccessNetwork := make(map[string]*UPNode, len(upi.AccessNetwork))
+	for name, node := range upi.AccessNetwork {
+		candidateAccessNetwork[name] = node
+	}
+
+	candidateUPFsID := make(map[string]string, len(upi.UPFsID))
+	for name, id := range upi.UPFsID {
+		candidateUPFsID[name] = id
+	}
+
+	candidateUPFsIPtoID := make(map[string]string, len(upi.UPFsIPtoID))
+	for ip, id := range upi.UPFsIPtoID {
+		candidateUPFsIPtoID[ip] = id
+	}
+
+	candidateUPFIPToName := make(map[string]string, len(upi.UPFIPToName))
+	for ip, name := range upi.UPFIPToName {
+		candidateUPFIPToName[ip] = name
+	}
+
+	createdUPFs := make([]*UPF, 0)
+	cleanupCreatedUPFs := func() {
+		for _, upf := range createdUPFs {
+			upfPool.Delete(upf.UUID())
+		}
+	}
+
 	for name, node := range upTopology.UPNodes {
-		if _, ok := upi.UPNodes[name]; ok {
+		if _, ok := candidateUPNodes[name]; ok {
 			logger.InitLog.Warningf("Node [%s] already exists in SMF.\n", name)
 			continue
 		}
 		upNode := new(UPNode)
+		upNode.Name = name
 		upNode.Type = UPNodeType(node.Type)
 		switch upNode.Type {
 		case UPNODE_UPF:
@@ -398,6 +436,7 @@ func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.Us
 			}
 
 			upNode.UPF = NewUPF(&upNode.NodeID, node.InterfaceUpfInfoList)
+			createdUPFs = append(createdUPFs, upNode.UPF)
 			snssaiInfos := make([]*SnssaiUPFInfo, 0)
 			for _, snssaiInfoConfig := range node.SNssaiInfos {
 				snssaiInfo := &SnssaiUPFInfo{
@@ -414,6 +453,7 @@ func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.Us
 					for _, pool := range dnnInfoConfig.Pools {
 						ueIPPool := NewUEIPPool(pool)
 						if ueIPPool == nil {
+							cleanupCreatedUPFs()
 							return fmt.Errorf("invalid pools value: %+v", pool)
 						} else {
 							ueIPPools = append(ueIPPools, ueIPPool)
@@ -422,12 +462,14 @@ func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.Us
 					for _, pool := range dnnInfoConfig.StaticPools {
 						ueIPPool := NewUEIPPool(pool)
 						if ueIPPool == nil {
+							cleanupCreatedUPFs()
 							return fmt.Errorf("invalid pools value: %+v", pool)
 						} else {
 							staticUeIPPools = append(staticUeIPPools, ueIPPool)
 							for _, dynamicUePool := range ueIPPools {
 								if dynamicUePool.ueSubNet.Contains(ueIPPool.ueSubNet.IP) {
 									if err := dynamicUePool.Exclude(ueIPPool); err != nil {
+										cleanupCreatedUPFs()
 										return fmt.Errorf("exclude static Pool[%s] failed: %v",
 											ueIPPool.ueSubNet, err)
 									}
@@ -446,30 +488,30 @@ func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.Us
 				snssaiInfos = append(snssaiInfos, snssaiInfo)
 			}
 			upNode.UPF.SNssaiInfos = snssaiInfos
-			upi.UPFs[name] = upNode
+			candidateUPFs[name] = upNode
 
 			// AllocateUPFID
 			upfid := upNode.UPF.UUID()
 			upfip := upNode.NodeID.ResolveNodeIdToIp().String()
-			upi.UPFsID[name] = upfid
-			upi.UPFsIPtoID[upfip] = upfid
+			candidateUPFsID[name] = upfid
+			candidateUPFsIPtoID[upfip] = upfid
 
 		case UPNODE_AN:
 			upNode.ANIP = net.ParseIP(node.ANIP)
-			upi.AccessNetwork[name] = upNode
+			candidateAccessNetwork[name] = upNode
 		default:
 			logger.InitLog.Warningf("invalid UPNodeType: %s\n", upNode.Type)
 		}
 
-		upi.UPNodes[name] = upNode
+		candidateUPNodes[name] = upNode
 
 		ipStr := upNode.NodeID.ResolveNodeIdToIp().String()
-		upi.UPFIPToName[ipStr] = name
+		candidateUPFIPToName[ipStr] = name
 	}
 
 	// overlap UE IP pool validation
 	allUEIPPools := []*UeIPPool{}
-	for _, upf := range upi.UPFs {
+	for _, upf := range candidateUPFs {
 		for _, snssaiInfo := range upf.UPF.SNssaiInfos {
 			for _, dnn := range snssaiInfo.DnnList {
 				allUEIPPools = append(allUEIPPools, dnn.UeIPPools...)
@@ -477,8 +519,16 @@ func (upi *UserPlaneInformation) UpNodesFromConfiguration(upTopology *factory.Us
 		}
 	}
 	if isOverlap(allUEIPPools) {
+		cleanupCreatedUPFs()
 		return fmt.Errorf("overlap cidr value between UPFs")
 	}
+
+	upi.UPNodes = candidateUPNodes
+	upi.UPFs = candidateUPFs
+	upi.AccessNetwork = candidateAccessNetwork
+	upi.UPFsID = candidateUPFsID
+	upi.UPFsIPtoID = candidateUPFsIPtoID
+	upi.UPFIPToName = candidateUPFIPToName
 
 	return nil
 }

--- a/internal/context/user_plane_information_test.go
+++ b/internal/context/user_plane_information_test.go
@@ -150,7 +150,8 @@ var configuration = &factory.UserPlaneInformation{
 }
 
 func TestNewUserPlaneInformation(t *testing.T) {
-	userplaneInformation := smf_context.NewUserPlaneInformation(configuration)
+	userplaneInformation, err := smf_context.NewUserPlaneInformation(configuration)
+	require.NoError(t, err)
 
 	require.NotNil(t, userplaneInformation.AccessNetwork["GNodeB"])
 
@@ -249,7 +250,8 @@ func TestGenerateDefaultPath(t *testing.T) {
 		},
 	}
 
-	userplaneInformation := smf_context.NewUserPlaneInformation(&config1)
+	userplaneInformation, err := smf_context.NewUserPlaneInformation(&config1)
+	require.NoError(t, err)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			pathExist := userplaneInformation.GenerateDefaultPath(tc.param)
@@ -268,7 +270,8 @@ func TestSelectUPFAndAllocUEIP(t *testing.T) {
 		expectedIPPool = append(expectedIPPool, net.ParseIP(fmt.Sprintf("10.60.0.%d", i)).To4())
 	}
 
-	userplaneInformation := smf_context.NewUserPlaneInformation(configuration)
+	userplaneInformation, err := smf_context.NewUserPlaneInformation(configuration)
+	require.NoError(t, err)
 	for _, upf := range userplaneInformation.UPFs {
 		upf.UPF.AssociationContext = context.Background()
 	}
@@ -485,7 +488,8 @@ var testCasesOfGetUEIPPool = []struct {
 }
 
 func TestGetUEIPPool(t *testing.T) {
-	userplaneInformation := smf_context.NewUserPlaneInformation(configForIPPoolAllocate)
+	userplaneInformation, err := smf_context.NewUserPlaneInformation(configForIPPoolAllocate)
+	require.NoError(t, err)
 	for _, upf := range userplaneInformation.UPFs {
 		upf.UPF.AssociationContext = context.Background()
 	}

--- a/internal/pfcp/message/build_test.go
+++ b/internal/pfcp/message/build_test.go
@@ -37,7 +37,9 @@ var testNodeID = &pfcpType.NodeID{
 }
 
 func initSmfContext() {
-	context.InitSmfContext(&testConfig)
+	if err := context.InitSmfContext(&testConfig); err != nil {
+		panic(err)
+	}
 }
 
 func initRuleList() ([]*context.PDR, []*context.FAR, []*context.BAR,

--- a/internal/sbi/api_upi.go
+++ b/internal/sbi/api_upi.go
@@ -69,7 +69,11 @@ func (s *Server) PostUpNodesLinks(c *gin.Context) {
 		return
 	}
 
-	upi.UpNodesFromConfiguration(&json)
+	if err := upi.UpNodesFromConfiguration(&json); err != nil {
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(http.StatusBadRequest)))
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 	upi.LinksFromConfiguration(&json)
 
 	for _, upf := range upi.UPFs {

--- a/internal/sbi/consumer/pcf_service_test.go
+++ b/internal/sbi/consumer/pcf_service_test.go
@@ -31,7 +31,7 @@ var testConfig = factory.Config{
 }
 
 func TestSendSMPolicyAssociationUpdateByUERequestModification(t *testing.T) {
-	smf_context.InitSmfContext(&testConfig)
+	require.NoError(t, smf_context.InitSmfContext(&testConfig))
 
 	testCases := []struct {
 		name         string

--- a/internal/sbi/processor/pdu_session_test.go
+++ b/internal/sbi/processor/pdu_session_test.go
@@ -119,7 +119,9 @@ var testConfig = factory.Config{
 }
 
 func initConfig() {
-	smf_context.InitSmfContext(&testConfig)
+	if err := smf_context.InitSmfContext(&testConfig); err != nil {
+		panic(err)
+	}
 	factory.SmfConfig = &testConfig
 }
 

--- a/internal/sbi/server.go
+++ b/internal/sbi/server.go
@@ -48,7 +48,9 @@ func NewServer(smf ServerSmf, tlsKeyLogPath string) (*Server, error) {
 		ServerSmf: smf,
 	}
 
-	smf_context.InitSmfContext(factory.SmfConfig)
+	if err := smf_context.InitSmfContext(factory.SmfConfig); err != nil {
+		return nil, err
+	}
 	// allocate id for each upf
 	smf_context.AllocateUPFID()
 	smf_context.InitSMFUERouting(factory.UERoutingConfig)


### PR DESCRIPTION
fix [issue 906](https://github.com/free5gc/free5gc/issues/906)

**Error Handling Improvements:**

- `InitSmfContext` in `context.go` now returns an error instead of logging fatally or returning nothing on configuration issues. All call sites (tests, server startup, etc.) are updated to handle this error appropriately, often failing fast if initialization fails.

- `NewUserPlaneInformation` now returns an error instead of calling `Fatalf` on invalid configuration (e.g., bad pools, overlapping CIDRs), and all call sites are updated to check and handle this error.

**User Plane Information Configuration:**

- `UpNodesFromConfiguration` is refactored to return an error on failure instead of logging fatally, and now uses a candidate structure to ensure atomic updates only on success. Cleanup logic is added for partial resource allocation on error.

**API Error Reporting:**

- The UPI API endpoint (`PostUpNodesLinks`) now returns a proper HTTP 400 error with details if `UpNodesFromConfiguration` fails, improving client feedback and debuggability.

**Testing and Test Infrastructure:**

- All affected tests are updated to check the new error returns from initialization functions, ensuring that test failures are clear and explicit when configuration is invalid. 
