### PR TITLE
fix: use safe type assertion for ProblemDetails in HandlePDUSessionSMContextCreate

### DIFF
--- a/internal/sbi/processor/pdu_session.go
+++ b/internal/sbi/processor/pdu_session.go
@@ -191,14 +191,15 @@ func (p *Processor) HandlePDUSessionSMContextCreate(
 	smPolicyID, smPolicyDecision, err := p.Consumer().SendSMPolicyAssociationCreate(smContext)
 	if err != nil {
 		if openapiError, ok := err.(openapi.GenericOpenAPIError); ok {
-			problemDetails := openapiError.Model().(models.ProblemDetails)
-			smContext.Log.Errorln("setup sm policy association failed:", err, problemDetails)
-			smContext.SetState(smf_context.InActive)
-			if problemDetails.Cause == "USER_UNKNOWN" {
-				p.makeEstRejectResAndReleaseSMContext(c, smContext,
-					nasMessage.Cause5GSMRequestRejectedUnspecified,
-					&smf_errors.SubscriptionDenied)
-				return
+			if problemDetails, ok := openapiError.Model().(models.ProblemDetails); ok {
+				smContext.Log.Errorln("setup sm policy association failed:", err, problemDetails)
+				smContext.SetState(smf_context.InActive)
+				if problemDetails.Cause == "USER_UNKNOWN" {
+					p.makeEstRejectResAndReleaseSMContext(c, smContext,
+						nasMessage.Cause5GSMRequestRejectedUnspecified,
+						&smf_errors.SubscriptionDenied)
+					return
+				}
 			}
 		}
 		p.makeEstRejectResAndReleaseSMContext(c, smContext,

--- a/internal/sbi/processor/pdu_session.go
+++ b/internal/sbi/processor/pdu_session.go
@@ -15,6 +15,7 @@ import (
 	"github.com/free5gc/nas/nasMessage"
 	"github.com/free5gc/openapi"
 	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/openapi/pcf/SMPolicyControl"
 	"github.com/free5gc/openapi/udm/SubscriberDataManagement"
 	"github.com/free5gc/pfcp/pfcpType"
 	smf_context "github.com/free5gc/smf/internal/context"
@@ -191,15 +192,20 @@ func (p *Processor) HandlePDUSessionSMContextCreate(
 	smPolicyID, smPolicyDecision, err := p.Consumer().SendSMPolicyAssociationCreate(smContext)
 	if err != nil {
 		if openapiError, ok := err.(openapi.GenericOpenAPIError); ok {
-			if problemDetails, okPd := openapiError.Model().(models.ProblemDetails); okPd {
-				smContext.Log.Errorln("setup sm policy association failed:", err, problemDetails)
+			switch errModel := openapiError.Model().(type) {
+			case SMPolicyControl.CreateSMPolicyError:
+				problemDetails := errModel.ProblemDetails
+				smContext.Log.Errorln("set sm policy association failed:", err, problemDetails)
 				smContext.SetState(smf_context.InActive)
+
 				if problemDetails.Cause == "USER_UNKNOWN" {
 					p.makeEstRejectResAndReleaseSMContext(c, smContext,
 						nasMessage.Cause5GSMRequestRejectedUnspecified,
 						&smf_errors.SubscriptionDenied)
 					return
 				}
+			default:
+				smContext.Log.Errorln("set sm policy association failed with unknown error model:", err)
 			}
 		}
 		p.makeEstRejectResAndReleaseSMContext(c, smContext,

--- a/internal/sbi/processor/pdu_session.go
+++ b/internal/sbi/processor/pdu_session.go
@@ -191,7 +191,7 @@ func (p *Processor) HandlePDUSessionSMContextCreate(
 	smPolicyID, smPolicyDecision, err := p.Consumer().SendSMPolicyAssociationCreate(smContext)
 	if err != nil {
 		if openapiError, ok := err.(openapi.GenericOpenAPIError); ok {
-			if problemDetails, ok := openapiError.Model().(models.ProblemDetails); ok {
+			if problemDetails, okPd := openapiError.Model().(models.ProblemDetails); okPd {
 				smContext.Log.Errorln("setup sm policy association failed:", err, problemDetails)
 				smContext.SetState(smf_context.InActive)
 				if problemDetails.Cause == "USER_UNKNOWN" {


### PR DESCRIPTION
## Summary

Fixes a runtime panic in `HandlePDUSessionSMContextCreate` when the PCF returns a non-`ProblemDetails` error model (e.g. `CreateSMPolicyError`) during SM policy association.

Closes #205

## Root cause

The PCF's `CreateSmPolicy` endpoint (3GPP TS 29.512) can return different error body types depending on the failure:

| HTTP status | Body type |
|-------------|-----------|
| 403 (USER_UNKNOWN, etc.) | `models.ProblemDetails` |
| 400 (missing SM policy data in UDR, etc.) | `SMPolicyControl.CreateSMPolicyError` |

The existing code used a bare (non-checking) type assertion:
```go
problemDetails := openapiError.Model().(models.ProblemDetails)
```
When the PCF returns a `CreateSMPolicyError`, `openapiError.Model()` holds that type instead of `ProblemDetails`, and the assertion panics.

## Change

Switch to the two-value form so that a `CreateSMPolicyError` (or any other non-`ProblemDetails` model) is handled gracefully by the existing fallback path:

```go
if problemDetails, ok := openapiError.Model().(models.ProblemDetails); ok {
    // USER_UNKNOWN and other ProblemDetails-carrying errors
}
// non-ProblemDetails errors fall through to makeEstRejectResAndReleaseSMContext below
```

## Test plan

- [x] Start free5GC v4.2.1 with a UE whose `policyData.ues.smData` is absent from UDR (simulate missing SM policy data — PCF returns HTTP 400 `CreateSMPolicyError`)
- [x] Attach UE — SMF returns a PDU Session Establishment Reject instead of panicking
- [x] Confirm normal flow still works once SM policy data is present