### PR TITLE
fix: handles already-released PFCP sessions

### DIFF
--- a/internal/context/sm_context.go
+++ b/internal/context/sm_context.go
@@ -168,6 +168,7 @@ type SMContext struct {
 	BPManager   *BPManager
 	// NodeID(string form) to PFCP Session Context
 	PFCPContext                         map[string]*PFCPSessionContext
+	PFCPReleaseDone                     bool
 	PDUSessionRelease_DUE_TO_DUP_PDU_ID bool
 
 	DNNInfo *SnssaiSmfDnnInfo

--- a/internal/sbi/processor/pdu_session.go
+++ b/internal/sbi/processor/pdu_session.go
@@ -1246,10 +1246,16 @@ func (p *Processor) HandlePDUSessionSMContextRelease(
 		}
 	}
 
-	if !smContext.CheckState(smf_context.InActive) {
-		smContext.SetState(smf_context.PFCPModification)
+	var pfcpResponseStatus smf_context.PFCPSessionResponseStatus
+	if smContext.State() == smf_context.InActivePending || smContext.State() == smf_context.InActive {
+		smContext.Log.Infof("PFCP session already released (State: %s), skip PFCP releaseSession", smContext.State().String())
+		pfcpResponseStatus = smf_context.SessionReleaseSuccess
+	} else {
+		if !smContext.CheckState(smf_context.InActive) {
+			smContext.SetState(smf_context.PFCPModification)
+		}
+		pfcpResponseStatus = releaseSession(smContext)
 	}
-	pfcpResponseStatus := releaseSession(smContext)
 
 	switch pfcpResponseStatus {
 	case smf_context.SessionReleaseSuccess:
@@ -1347,9 +1353,14 @@ func (p *Processor) HandlePDUSessionSMContextLocalRelease(
 		}
 	}
 
-	smContext.SetState(smf_context.PFCPModification)
-
-	pfcpResponseStatus := releaseSession(smContext)
+	var pfcpResponseStatus smf_context.PFCPSessionResponseStatus
+	if smContext.State() == smf_context.InActivePending || smContext.State() == smf_context.InActive {
+		smContext.Log.Infof("PFCP session already released (State: %s), skip PFCP releaseSession", smContext.State().String())
+		pfcpResponseStatus = smf_context.SessionReleaseSuccess
+	} else {
+		smContext.SetState(smf_context.PFCPModification)
+		pfcpResponseStatus = releaseSession(smContext)
+	}
 
 	switch pfcpResponseStatus {
 	case smf_context.SessionReleaseSuccess:

--- a/internal/sbi/processor/pdu_session.go
+++ b/internal/sbi/processor/pdu_session.go
@@ -1247,13 +1247,10 @@ func (p *Processor) HandlePDUSessionSMContextRelease(
 	}
 
 	var pfcpResponseStatus smf_context.PFCPSessionResponseStatus
-	if smContext.State() == smf_context.InActivePending || smContext.State() == smf_context.InActive {
+	if smContext.PFCPReleaseDone {
 		smContext.Log.Infof("PFCP session already released (State: %s), skip PFCP releaseSession", smContext.State().String())
 		pfcpResponseStatus = smf_context.SessionReleaseSuccess
 	} else {
-		if !smContext.CheckState(smf_context.InActive) {
-			smContext.SetState(smf_context.PFCPModification)
-		}
 		pfcpResponseStatus = releaseSession(smContext)
 	}
 
@@ -1354,11 +1351,10 @@ func (p *Processor) HandlePDUSessionSMContextLocalRelease(
 	}
 
 	var pfcpResponseStatus smf_context.PFCPSessionResponseStatus
-	if smContext.State() == smf_context.InActivePending || smContext.State() == smf_context.InActive {
+	if smContext.PFCPReleaseDone {
 		smContext.Log.Infof("PFCP session already released (State: %s), skip PFCP releaseSession", smContext.State().String())
 		pfcpResponseStatus = smf_context.SessionReleaseSuccess
 	} else {
-		smContext.SetState(smf_context.PFCPModification)
 		pfcpResponseStatus = releaseSession(smContext)
 	}
 
@@ -1396,6 +1392,7 @@ func (p *Processor) HandlePDUSessionSMContextLocalRelease(
 }
 
 func releaseSession(smContext *smf_context.SMContext) smf_context.PFCPSessionResponseStatus {
+	smContext.PFCPReleaseDone = false
 	smContext.SetState(smf_context.PFCPModification)
 
 	for _, res := range ReleaseTunnel(smContext) {
@@ -1404,6 +1401,7 @@ func releaseSession(smContext *smf_context.SMContext) smf_context.PFCPSessionRes
 		}
 	}
 	if !smContext.NrdcIndicator {
+		smContext.PFCPReleaseDone = true
 		return smf_context.SessionReleaseSuccess
 	}
 
@@ -1412,6 +1410,7 @@ func releaseSession(smContext *smf_context.SMContext) smf_context.PFCPSessionRes
 			return res.Status
 		}
 	}
+	smContext.PFCPReleaseDone = true
 	return smf_context.SessionReleaseSuccess
 }
 


### PR DESCRIPTION
fix [issue#1003](https://github.com/free5gc/free5gc/issues/1003)

This pull request introduces a mechanism to prevent redundant PFCP session release operations by tracking the release status within the `SMContext`. The main change is the addition of a `PFCPReleaseDone` flag, which ensures that PFCP session release logic is only executed once per context, improving the robustness and efficiency of session management.

**Session Release Idempotency Improvements:**
* Added a `PFCPReleaseDone` boolean field to the `SMContext` struct to track whether the PFCP session has already been released, preventing duplicate release attempts.
* Updated `HandlePDUSessionSMContextRelease` and `HandlePDUSessionSMContextLocalRelease` to check `PFCPReleaseDone` before attempting to release the PFCP session, logging and skipping the release if it has already been performed. 

**Session Release Logic Updates:**
* Modified the `releaseSession` function to set `PFCPReleaseDone` to `false` at the start and to `true` upon successful session release, ensuring accurate tracking of the release status.