### PR TITLE
fix: handle missing QoS flow entries in PDU session resource modify response

### DIFF
--- a/internal/context/ngap_handler.go
+++ b/internal/context/ngap_handler.go
@@ -108,7 +108,11 @@ func HandlePDUSessionResourceModifyResponseTransfer(b []byte, ctx *SMContext) er
 	if qosInfoList := resourceModifyResponseTransfer.QosFlowAddOrModifyResponseList; qosInfoList != nil {
 		for _, item := range qosInfoList.List {
 			qfi := uint8(item.QosFlowIdentifier.Value)
-			ctx.AdditonalQosFlows[qfi].State = QoSFlowSet
+			if qosFlow, ok := ctx.AdditonalQosFlows[qfi]; ok {
+				qosFlow.State = QoSFlowSet
+			} else {
+				logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] not found in AdditonalQosFlows", qfi)
+			}
 		}
 	}
 
@@ -118,7 +122,11 @@ func HandlePDUSessionResourceModifyResponseTransfer(b []byte, ctx *SMContext) er
 			logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] %s",
 				qfi, strNgapCause(&item.Cause))
 
-			ctx.AdditonalQosFlows[qfi].State = QoSFlowUnset
+			if qosFlow, ok := ctx.AdditonalQosFlows[qfi]; ok {
+				qosFlow.State = QoSFlowUnset
+			} else {
+				logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] not found in AdditonalQosFlows", qfi)
+			}
 		}
 	}
 

--- a/internal/context/ngap_handler.go
+++ b/internal/context/ngap_handler.go
@@ -111,7 +111,7 @@ func HandlePDUSessionResourceModifyResponseTransfer(b []byte, ctx *SMContext) er
 			if qosFlow, ok := ctx.AdditonalQosFlows[qfi]; ok {
 				qosFlow.State = QoSFlowSet
 			} else {
-				logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] not found in AdditonalQosFlows", qfi)
+				logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] not found in AdditionalQosFlows", qfi)
 			}
 		}
 	}
@@ -125,7 +125,7 @@ func HandlePDUSessionResourceModifyResponseTransfer(b []byte, ctx *SMContext) er
 			if qosFlow, ok := ctx.AdditonalQosFlows[qfi]; ok {
 				qosFlow.State = QoSFlowUnset
 			} else {
-				logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] not found in AdditonalQosFlows", qfi)
+				logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] not found in AdditionalQosFlows", qfi)
 			}
 		}
 	}
@@ -252,14 +252,18 @@ func HandlePathSwitchRequestTransfer(b []byte, ctx *SMContext) error {
 	// update the DC tunnel AN information from Additional DL QoS Flow per TNL Information at IE Extensions
 	if ctx.NrdcIndicator {
 		ieExtensions := pathSwitchRequestTransfer.IEExtensions
-		for _, ie := range ieExtensions.List {
-			if ie.Id.Value == ngapType.ProtocolIEIDAdditionalDLQosFlowPerTNLInformation {
-				qosFlowInfo := ie.ExtensionValue.AdditionalDLQosFlowPerTNLInformation.List[0]
-				DCGTPTunnel := qosFlowInfo.QosFlowPerTNLInformation.UPTransportLayerInformation.GTPTunnel
-				ctx.DCTunnel.UpdateANInformation(
-					DCGTPTunnel.TransportLayerAddress.Value.Bytes,
-					binary.BigEndian.Uint32(DCGTPTunnel.GTPTEID.Value))
-				break
+		if ieExtensions == nil {
+			logger.PduSessLog.Warnf("PathSwitchRequestTransfer IEExtensions is nil when NRDC is activated")
+		} else {
+			for _, ie := range ieExtensions.List {
+				if ie.Id.Value == ngapType.ProtocolIEIDAdditionalDLQosFlowPerTNLInformation {
+					qosFlowInfo := ie.ExtensionValue.AdditionalDLQosFlowPerTNLInformation.List[0]
+					DCGTPTunnel := qosFlowInfo.QosFlowPerTNLInformation.UPTransportLayerInformation.GTPTunnel
+					ctx.DCTunnel.UpdateANInformation(
+						DCGTPTunnel.TransportLayerAddress.Value.Bytes,
+						binary.BigEndian.Uint32(DCGTPTunnel.GTPTEID.Value))
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
fix [issue#1016](https://github.com/free5gc/free5gc/issues/1016) [issue#1019](https://github.com/free5gc/free5gc/issues/1019)

This pull request improves error handling and logging in the `internal/context/ngap_handler.go` file, specifically in the handling of PDU Session Resource Modify and Path Switch Request procedures. The changes ensure the code safely checks for the existence of QoS Flow entries and IE extensions before accessing them, preventing potential runtime panics and improving debuggability.

**Error handling and logging improvements:**
* Added checks to ensure a QFI exists in `ctx.AdditonalQosFlows` before updating its `State` in `HandlePDUSessionResourceModifyResponseTransfer`, with warnings logged if not found. 
* Added a check for `IEExtensions` being `nil` in `HandlePathSwitchRequestTransfer` when `NrdcIndicator` is active, logging a warning if missing.
* Ensured the function gracefully handles the case where `IEExtensions` is `nil` by avoiding further processing.