### PR TITLE
context/ngap: skip DC tunnel update when PathSwitchRequest has no IEExtensions

### DIFF
--- a/internal/context/ngap_handler.go
+++ b/internal/context/ngap_handler.go
@@ -244,6 +244,13 @@ func HandlePathSwitchRequestTransfer(b []byte, ctx *SMContext) error {
 	// update the DC tunnel AN information from Additional DL QoS Flow per TNL Information at IE Extensions
 	if ctx.NrdcIndicator {
 		ieExtensions := pathSwitchRequestTransfer.IEExtensions
+		// IEExtensions is aper:"optional" on PathSwitchRequestTransfer so
+		// a well-formed but stripped-down PathSwitchRequest can omit it
+		// entirely. Skip the DC-tunnel update in that case rather than
+		// panicking on the nil pointer (free5gc/free5gc#1019).
+		if ieExtensions == nil {
+			return nil
+		}
 		for _, ie := range ieExtensions.List {
 			if ie.Id.Value == ngapType.ProtocolIEIDAdditionalDLQosFlowPerTNLInformation {
 				qosFlowInfo := ie.ExtensionValue.AdditionalDLQosFlowPerTNLInformation.List[0]


### PR DESCRIPTION
## Bug

`HandlePathSwitchRequestTransfer` in `internal/context/ngap_handler.go` dereferences `pathSwitchRequestTransfer.IEExtensions.List` whenever `SMContext.NrdcIndicator` is true. `IEExtensions` is declared `aper:"optional"` on `PathSwitchRequestTransfer`, so any well-formed `PathSwitchRequest` that simply omits the extension chain panics the SMF with a nil-pointer dereference at `ngap_handler.go:247` (free5gc/free5gc#1019):

```
panic: runtime error: invalid memory address or nil pointer dereference
    github.com/free5gc/smf/internal/context.HandlePathSwitchRequestTransfer
    internal/context/ngap_handler.go:247
```

Fixes free5gc/free5gc#1019.

## Change

Short-circuit the DC-tunnel update when `IEExtensions == nil`:

```go
if ieExtensions == nil {
    return nil
}
```

The optional `AdditionalDLQosFlowPerTNLInformation` can't be present if the enclosing extension container is absent, so there's nothing to apply on that path. The non-NRDC branches above are untouched.

## Testing

- `go build ./...` passes.
- Local regression: invoked `HandlePathSwitchRequestTransfer` with a `PathSwitchRequestTransfer` that leaves `IEExtensions` unset and `ctx.NrdcIndicator=true`. Previously it panicked; now it returns `nil` and the rest of the SMF flow continues.
