### PR TITLE
context/ngap: skip unknown QFI in PDUSessionResourceModifyResponse

### DIFF
--- a/internal/context/ngap_handler.go
+++ b/internal/context/ngap_handler.go
@@ -108,7 +108,17 @@ func HandlePDUSessionResourceModifyResponseTransfer(b []byte, ctx *SMContext) er
 	if qosInfoList := resourceModifyResponseTransfer.QosFlowAddOrModifyResponseList; qosInfoList != nil {
 		for _, item := range qosInfoList.List {
 			qfi := uint8(item.QosFlowIdentifier.Value)
-			ctx.AdditonalQosFlows[qfi].State = QoSFlowSet
+			// A gNB can send a QFI that SMF never added to AdditonalQosFlows
+			// (unsolicited NGAP PDUSessionResourceModifyResponse). The map
+			// lookup returns a nil *QoSFlow and `.State = ...` then panics,
+			// killing the goroutine and surfacing HTTP 500 on N11 back to AMF.
+			// Skip unknown QFIs with a warning instead.
+			qos, ok := ctx.AdditonalQosFlows[qfi]
+			if !ok || qos == nil {
+				logger.PduSessLog.Warnf("PDU Session Resource Modify response referenced unknown QFI[%d]; ignoring", qfi)
+				continue
+			}
+			qos.State = QoSFlowSet
 		}
 	}
 
@@ -118,7 +128,12 @@ func HandlePDUSessionResourceModifyResponseTransfer(b []byte, ctx *SMContext) er
 			logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] %s",
 				qfi, strNgapCause(&item.Cause))
 
-			ctx.AdditonalQosFlows[qfi].State = QoSFlowUnset
+			qos, ok := ctx.AdditonalQosFlows[qfi]
+			if !ok || qos == nil {
+				logger.PduSessLog.Warnf("PDU Session Resource Modify failed-list referenced unknown QFI[%d]; ignoring", qfi)
+				continue
+			}
+			qos.State = QoSFlowUnset
 		}
 	}
 


### PR DESCRIPTION
## Summary

`HandlePDUSessionResourceModifyResponseTransfer` indexed `ctx.AdditonalQosFlows` with every QFI received in the NGAP response without checking whether SMF had added that QFI. Because the map value type is `*QoSFlow`, an unknown QFI resolves to a nil pointer, and the immediate write to `.State` panics with nil pointer dereference.

A gNB (or simulator) can trigger this deterministically with an unsolicited `NGAP PDUSessionResourceModifyResponse` whose `QosFlowAddOrModifyResponseList` carries a QFI that SMF never added. The goroutine dies, the N11 SM Context Update returns HTTP 500 to AMF, and the SM Context's QoS flow bookkeeping drifts from the radio bearer state on the gNB.

## Fix

Look up the QFI, skip and log a warning when the map entry is missing or nil. Applied symmetrically to the `QosFlowFailedToAddOrModifyList` branch so a failure list cannot panic either.

Fixes free5gc/free5gc#1016.

## Test

- `go build ./...` green.
- `go vet ./...` clean.
- `go test ./internal/context/... -count=1` passes.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
