### PR TITLE
fix: implement allowed NF types for service and add unit tests

### DIFF
--- a/internal/context/nf_profile.go
+++ b/internal/context/nf_profile.go
@@ -47,7 +47,7 @@ func (c *SMFContext) SetupNFProfile(nfProfileconfig *factory.Config) {
 			},
 		}
 
-		if allowedNfTypes := allowedNfTypesForService(models.ServiceName(serviceName)); len(allowedNfTypes) > 0 {
+		if allowedNfTypes := AllowedNfTypesForService(models.ServiceName(serviceName)); len(allowedNfTypes) > 0 {
 			nfService.AllowedNfTypes = allowedNfTypes
 		}
 
@@ -71,7 +71,7 @@ func (c *SMFContext) SetupNFProfile(nfProfileconfig *factory.Config) {
 	}
 }
 
-func allowedNfTypesForService(serviceName models.ServiceName) []models.NrfNfManagementNfType {
+func AllowedNfTypesForService(serviceName models.ServiceName) []models.NrfNfManagementNfType {
 	switch serviceName {
 	case models.ServiceName_NSMF_PDUSESSION:
 		// N11 `/sm-contexts` is consumed by AMF and inter-SMF procedures.

--- a/internal/context/nf_profile.go
+++ b/internal/context/nf_profile.go
@@ -32,7 +32,7 @@ func (c *SMFContext) SetupNFProfile(nfProfileconfig *factory.Config) {
 	// set NFServices
 	c.NfProfile.NFServices = new([]models.NrfNfManagementNfService)
 	for _, serviceName := range nfProfileconfig.Configuration.ServiceNameList {
-		*c.NfProfile.NFServices = append(*c.NfProfile.NFServices, models.NrfNfManagementNfService{
+		nfService := models.NrfNfManagementNfService{
 			ServiceInstanceId: GetSelf().NfInstanceID + serviceName,
 			ServiceName:       models.ServiceName(serviceName),
 			Versions:          *c.NfProfile.NFServiceVersion,
@@ -45,7 +45,13 @@ func (c *SMFContext) SetupNFProfile(nfProfileconfig *factory.Config) {
 					Port:        int32(GetSelf().SBIPort),
 				},
 			},
-		})
+		}
+
+		if allowedNfTypes := allowedNfTypesForService(models.ServiceName(serviceName)); len(allowedNfTypes) > 0 {
+			nfService.AllowedNfTypes = allowedNfTypes
+		}
+
+		*c.NfProfile.NFServices = append(*c.NfProfile.NFServices, nfService)
 	}
 
 	// set smfInfo
@@ -62,6 +68,19 @@ func (c *SMFContext) SetupNFProfile(nfProfileconfig *factory.Config) {
 				Mnc: plmn.Mnc,
 			})
 		}
+	}
+}
+
+func allowedNfTypesForService(serviceName models.ServiceName) []models.NrfNfManagementNfType {
+	switch serviceName {
+	case models.ServiceName_NSMF_PDUSESSION:
+		// N11 `/sm-contexts` is consumed by AMF and inter-SMF procedures.
+		return []models.NrfNfManagementNfType{
+			models.NrfNfManagementNfType_AMF,
+			models.NrfNfManagementNfType_SMF,
+		}
+	default:
+		return nil
 	}
 }
 

--- a/internal/context/nf_profile_test.go
+++ b/internal/context/nf_profile_test.go
@@ -1,11 +1,12 @@
 package context_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/free5gc/openapi/models"
 	smf_context "github.com/free5gc/smf/internal/context"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllowedNfTypesForService(t *testing.T) {
@@ -32,9 +33,7 @@ func TestAllowedNfTypesForService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := smf_context.AllowedNfTypesForService(tt.serviceName)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("AllowedNfTypesForService(%q) = %v, want %v", tt.serviceName, got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/context/nf_profile_test.go
+++ b/internal/context/nf_profile_test.go
@@ -2,11 +2,10 @@ package context_test
 
 import (
 	"testing"
-
+	"github.com/stretchr/testify/require"
+	
 	"github.com/free5gc/openapi/models"
 	smf_context "github.com/free5gc/smf/internal/context"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestAllowedNfTypesForService(t *testing.T) {

--- a/internal/context/nf_profile_test.go
+++ b/internal/context/nf_profile_test.go
@@ -2,8 +2,9 @@ package context_test
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/require"
-	
+
 	"github.com/free5gc/openapi/models"
 	smf_context "github.com/free5gc/smf/internal/context"
 )

--- a/internal/context/nf_profile_test.go
+++ b/internal/context/nf_profile_test.go
@@ -1,0 +1,39 @@
+package context
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/free5gc/openapi/models"
+)
+
+func TestAllowedNfTypesForService(t *testing.T) {
+	tests := []struct {
+		name        string
+		serviceName models.ServiceName
+		want        []models.NrfNfManagementNfType
+	}{
+		{
+			name:        "nsmf-pdusession allows AMF and SMF",
+			serviceName: models.ServiceName_NSMF_PDUSESSION,
+			want: []models.NrfNfManagementNfType{
+				models.NrfNfManagementNfType_AMF,
+				models.NrfNfManagementNfType_SMF,
+			},
+		},
+		{
+			name:        "other services remain unrestricted",
+			serviceName: models.ServiceName_NSMF_EVENT_EXPOSURE,
+			want:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allowedNfTypesForService(tt.serviceName)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("allowedNfTypesForService(%q) = %v, want %v", tt.serviceName, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/context/nf_profile_test.go
+++ b/internal/context/nf_profile_test.go
@@ -1,10 +1,11 @@
-package context
+package context_test
 
 import (
 	"reflect"
 	"testing"
 
 	"github.com/free5gc/openapi/models"
+	smf_context "github.com/free5gc/smf/internal/context"
 )
 
 func TestAllowedNfTypesForService(t *testing.T) {
@@ -30,9 +31,9 @@ func TestAllowedNfTypesForService(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := allowedNfTypesForService(tt.serviceName)
+			got := smf_context.AllowedNfTypesForService(tt.serviceName)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("allowedNfTypesForService(%q) = %v, want %v", tt.serviceName, got, tt.want)
+				t.Fatalf("AllowedNfTypesForService(%q) = %v, want %v", tt.serviceName, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
fix [issue #852](https://github.com/free5gc/free5gc/issues/852)

This pull request enhances the logic for setting allowed NF types for each service in the NF profile and adds targeted unit tests to ensure correct behavior. The main improvement is that the `AllowedNfTypes` field is now restricting the `nsmf-pdusession` service to AMF and SMF consumers. 

According to 3GPP TS 29.502 Section 5.2.1, the valid consumers for the Nsmf_PDUSession service are strictly limited to AMF and SMF. This commit registers the AllowedNfTypes for the nsmf-pdusession NF profile to NRF, preventing unauthorized NFs (e.g., NEF) from obtaining OAuth2 access tokens and reaching the SMF business logic.