### PR TITLE
fix: add warnings for empty NfInstances in UDM and AMF discovery

### DIFF
--- a/internal/sbi/consumer/nrf_service.go
+++ b/internal/sbi/consumer/nrf_service.go
@@ -296,6 +296,10 @@ func (s *nnrfService) SendNFDiscoveryUDM() (*models.ProblemDetails, error) {
 	case error:
 		return openapi.ProblemDetailsSystemFailure(err.Error()), nil
 	case nil:
+		if len(result.NfInstances) == 0 {
+			logger.ConsumerLog.Warnln("UDM discovery returned empty NfInstances")
+			return nil, openapi.ReportError("UDM discovery returned empty NfInstances")
+		}
 		smfContext.UDMProfile = result.NfInstances[0]
 
 		var client *SubscriberDataManagement.APIClient
@@ -370,6 +374,10 @@ func (s *nnrfService) SendNFDiscoveryServingAMF(smContext *smf_context.SMContext
 		if result.NfInstances == nil {
 			logger.ConsumerLog.Warnln("NfInstances is nil")
 			return nil, openapi.ReportError("NfInstances is nil")
+		}
+		if len(result.NfInstances) == 0 {
+			logger.ConsumerLog.Warnln("AMF NfInstances is empty")
+			return nil, openapi.ReportError("AMF NfInstances is empty")
 		}
 		logger.ConsumerLog.Info("SendNFDiscoveryServingAMF ok")
 		smContext.AMFProfile = result.NfInstances[0]


### PR DESCRIPTION
fix [issue #907](https://github.com/free5gc/free5gc/issues/907)

This pull request adds additional error handling to the NRF service discovery logic to ensure that empty NF instance discovery results are properly detected and reported. Specifically, it introduces checks for empty `NfInstances` arrays in both UDM and AMF discovery flows, improving robustness and logging for these scenarios.

Error handling improvements:

* Added a check for empty `NfInstances` after UDM discovery in `SendNFDiscoveryUDM`, logging a warning and returning an error if none are found.
* Added a check for empty `NfInstances` after AMF discovery in `SendNFDiscoveryServingAMF`, logging a warning and returning an error if none are found.