### PR TITLE
fix: handle case when no PCF is found in PCFSelection

### DIFF
--- a/internal/sbi/consumer/nrf_service.go
+++ b/internal/sbi/consumer/nrf_service.go
@@ -446,7 +446,9 @@ func (s *nnrfService) PCFSelection(smContext *smf_context.SMContext) error {
 	}
 
 	// Select PCF from available PCF
-
+	if res == nil || len(res.SearchResult.NfInstances) == 0 {
+		return fmt.Errorf("no PCF found in PCFSelection")
+	}
 	smContext.SelectedPCFProfile = res.SearchResult.NfInstances[0]
 
 	return nil


### PR DESCRIPTION
fixing [issue 1046](https://github.com/free5gc/free5gc/issues/1046)

This pull request adds a safety check to the `PCFSelection` method in `nrf_service.go` to handle cases where no PCF instances are found, preventing potential nil pointer errors.

Error handling improvement:

* Added a check to return an error if `res` is nil or if there are no PCF instances found in `res.SearchResult.NfInstances` within the `PCFSelection` method of `nrf_service.go`.