### PR TITLE
fix: correct typo in AdditionalQosFlows variable name

### DIFF
--- a/internal/context/gsm_build.go
+++ b/internal/context/gsm_build.go
@@ -100,7 +100,7 @@ func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error)
 	parameter.FiveQI = uint8(authDefQos.Var5qi)
 	dafaultAuthDesc.Parameters = append(dafaultAuthDesc.Parameters, parameter)
 	authDescs = append(authDescs, dafaultAuthDesc)
-	for _, qosFlow := range smContext.AdditonalQosFlows {
+	for _, qosFlow := range smContext.AdditionalQosFlows {
 		if qosDesc, e := qosFlow.BuildNasQoSDesc(nasType.OperationCodeCreateNewQoSFlowDescription); e != nil {
 			logger.GsmLog.Warnf("Create QoS Desc from qos flow error: %s\n", e)
 		} else {

--- a/internal/context/ngap_build.go
+++ b/internal/context/ngap_build.go
@@ -156,7 +156,7 @@ func BuildPDUSessionResourceSetupRequestTransfer(ctx *SMContext) ([]byte, error)
 		},
 	}
 
-	for _, qosFlow := range ctx.AdditonalQosFlows {
+	for _, qosFlow := range ctx.AdditionalQosFlows {
 		if qosDesc, err := qosFlow.BuildNgapQosFlowSetupRequestItem(); err != nil {
 			return nil, fmt.Errorf("encode BuildNgapQosFlowSetupRequestItem failed: %s", err)
 		} else {
@@ -240,7 +240,7 @@ func BuildPDUSessionResourceModifyRequestTransfer(ctx *SMContext) ([]byte, error
 	ie.Value.QosFlowAddOrModifyRequestList = new(ngapType.QosFlowAddOrModifyRequestList)
 	qosFlowAddOrModifyRequestList := ie.Value.QosFlowAddOrModifyRequestList
 
-	for _, qos := range ctx.AdditonalQosFlows {
+	for _, qos := range ctx.AdditionalQosFlows {
 		if qos.State == QoSFlowUnset || qos.State == QoSFlowToBeModify {
 			if qosDesc, err := qos.BuildNgapQosFlowAddOrModifyRequestItem(); err != nil {
 				return nil, fmt.Errorf("BuildNgapQosFlowSetupRequestItem failed: %s", err)

--- a/internal/context/ngap_handler.go
+++ b/internal/context/ngap_handler.go
@@ -83,7 +83,7 @@ func HandlePDUSessionResourceSetupResponseTransfer(b []byte, ctx *SMContext) err
 	}
 
 	ctx.UpCnxState = models.UpCnxState_ACTIVATED
-	for _, qos := range ctx.AdditonalQosFlows {
+	for _, qos := range ctx.AdditionalQosFlows {
 		qos.State = QoSFlowSet
 	}
 	return nil
@@ -108,7 +108,7 @@ func HandlePDUSessionResourceModifyResponseTransfer(b []byte, ctx *SMContext) er
 	if qosInfoList := resourceModifyResponseTransfer.QosFlowAddOrModifyResponseList; qosInfoList != nil {
 		for _, item := range qosInfoList.List {
 			qfi := uint8(item.QosFlowIdentifier.Value)
-			if qosFlow, ok := ctx.AdditonalQosFlows[qfi]; ok {
+			if qosFlow, ok := ctx.AdditionalQosFlows[qfi]; ok {
 				qosFlow.State = QoSFlowSet
 			} else {
 				logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] not found in AdditionalQosFlows", qfi)
@@ -122,7 +122,7 @@ func HandlePDUSessionResourceModifyResponseTransfer(b []byte, ctx *SMContext) er
 			logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] %s",
 				qfi, strNgapCause(&item.Cause))
 
-			if qosFlow, ok := ctx.AdditonalQosFlows[qfi]; ok {
+			if qosFlow, ok := ctx.AdditionalQosFlows[qfi]; ok {
 				qosFlow.State = QoSFlowUnset
 			} else {
 				logger.PduSessLog.Warnf("PDU Session Resource Modify QFI[%d] not found in AdditionalQosFlows", qfi)

--- a/internal/context/sm_context.go
+++ b/internal/context/sm_context.go
@@ -197,7 +197,7 @@ type SMContext struct {
 	PacketFilterIDToNASPFID map[string]uint8
 	AMBRQerMap              map[uuid.UUID]uint32
 	QerUpfMap               map[string]uint32
-	AdditonalQosFlows       map[uint8]*QoSFlow // Key: qfi
+	AdditionalQosFlows      map[uint8]*QoSFlow // Key: qfi
 
 	// URR
 	UrrIDGenerator     *idgenerator.IDGenerator
@@ -325,7 +325,7 @@ func NewSMContext(id string, pduSessID int32) *SMContext {
 	smContext.qosDataToQFI = make(map[string]uint8)
 	smContext.AMBRQerMap = make(map[uuid.UUID]uint32)
 	smContext.QerUpfMap = make(map[string]uint32)
-	smContext.AdditonalQosFlows = make(map[uint8]*QoSFlow)
+	smContext.AdditionalQosFlows = make(map[uint8]*QoSFlow)
 	smContext.UrrIDGenerator = idgenerator.NewGenerator(1, math.MaxUint32)
 	smContext.UrrIdMap = make(map[UrrType]uint32)
 	smContext.GenerateUrrId()

--- a/internal/context/sm_context_policy.go
+++ b/internal/context/sm_context_policy.go
@@ -61,12 +61,12 @@ func (c *SMContext) ApplySessionRules(
 func (c *SMContext) AddQosFlow(qfi uint8, qos *models.QosData) {
 	qosFlow := NewQoSFlow(qfi, qos)
 	if qosFlow != nil {
-		c.AdditonalQosFlows[qfi] = qosFlow
+		c.AdditionalQosFlows[qfi] = qosFlow
 	}
 }
 
 func (c *SMContext) RemoveQosFlow(qfi uint8) {
-	delete(c.AdditonalQosFlows, qfi)
+	delete(c.AdditionalQosFlows, qfi)
 }
 
 func (c *SMContext) ApplyPccRules(decision *models.SmPolicyDecision) error {


### PR DESCRIPTION
This pull request corrects a consistent typo in the `SMContext` struct and related code, changing all instances of the field name `AdditonalQosFlows` to `AdditionalQosFlows`. This improves code readability and prevents potential bugs caused by inconsistent naming.
