### PR TITLE
Test: add golden tests for message builders and openapi serialization

### DIFF
--- a/internal/context/gsm_build_internal_test.go
+++ b/internal/context/gsm_build_internal_test.go
@@ -47,11 +47,12 @@ func newGSMTestContext() *SMContext {
 
 func TestGoldenBuildGSMPDUSessionEstablishmentAccept(t *testing.T) {
 	testCases := []struct {
-		name         string
-		setupContext func() *SMContext
-		wantCause    uint8 // 0 = Cause5GSM IE absent
-		wantQoSRules int
-		golden       []byte
+		name          string
+		setupContext  func() *SMContext
+		wantCause     uint8 // 0 = Cause5GSM IE absent
+		wantQoSRules  int
+		wantPFsInRule int // packet filters in the 2nd QoS rule; 0 = skip check
+		golden        []byte
 	}{
 		{
 			name:         "Minimal",
@@ -119,6 +120,93 @@ func TestGoldenBuildGSMPDUSessionEstablishmentAccept(t *testing.T) {
 				0x65, 0x72, 0x6e, 0x65, 0x74,
 			},
 		},
+		{
+			// Exercises the packet-filter forms Minimal/Full do not reach:
+			// address CIDR (local+remote), single port, port range, protocol
+			// number, ToS marking, IPsec SPI, and the src-only/dst-only port
+			// cases of TS 24.501 9.11.4.13.4 — plus the GBR branch of
+			// BuildNasQoSDesc (GFBR/MFBR parameters from bitrate strings).
+			name: "GBRFlowAndPacketFilterForms",
+			setupContext: func() *SMContext {
+				smContext := newGSMTestContext()
+				// exactly ONE PCC rule (map!): FlowInfos is a slice, so
+				// multiple packet filters stay deterministic
+				smContext.PCCRules = map[string]*PCCRule{
+					"PccRuleId-2": {
+						PccRule: &models.PccRule{
+							PccRuleId:  "PccRuleId-2",
+							Precedence: 100,
+							FlowInfos: []models.FlowInformation{
+								{
+									// remote addr + single remote port, local addr +
+									// local port range, protocol TCP(6)
+									FlowDescription: "permit out 6 from 10.10.0.0/16 1000 to 10.60.0.1/32 2000-3000",
+									PackFiltId:      "PackFiltId-2",
+									FlowDirection:   models.FlowDirection_BIDIRECTIONAL,
+								},
+								{
+									// remote port range + single local port + ToS, UDP(17)
+									FlowDescription: "permit out 17 from 10.20.0.0/16 5000-6000 to 10.60.0.1/32 443",
+									TosTrafficClass: "28ff",
+									PackFiltId:      "PackFiltId-3",
+									FlowDirection:   models.FlowDirection_DOWNLINK,
+								},
+								{
+									// local-port-only case (srcPLen==0 && dstPLen>0)
+									FlowDescription: "permit out ip from any to 10.60.0.1/32 8080",
+									PackFiltId:      "PackFiltId-4",
+									FlowDirection:   models.FlowDirection_UPLINK,
+								},
+								{
+									// remote-port-only case (srcPLen>0 && dstPLen==0) + SPI
+									FlowDescription: "permit out ip from 10.30.0.0/16 9000 to assigned",
+									Spi:             "1a2b3c",
+									PackFiltId:      "PackFiltId-5",
+									FlowDirection:   models.FlowDirection_BIDIRECTIONAL,
+								},
+							},
+						},
+						QFI: 2,
+					},
+				}
+				smContext.AdditionalQosFlows = map[uint8]*QoSFlow{
+					2: NewQoSFlow(2, &models.QosData{
+						Var5qi:  1, // standard GBR 5QI -> IsGBRFlow() is true
+						GbrDl:   "100 Mbps",
+						GbrUl:   "50 Mbps",
+						MaxbrDl: "200 Mbps",
+						MaxbrUl: "150 Mbps",
+						Arp: &models.Arp{
+							PriorityLevel: 8,
+							PreemptCap:    models.PreemptionCapability_NOT_PREEMPT,
+							PreemptVuln:   models.PreemptionVulnerability_NOT_PREEMPTABLE,
+						},
+					}),
+				}
+				return smContext
+			},
+			wantCause:     0,
+			wantQoSRules:  2,
+			wantPFsInRule: 4, // FlowInfo 1-4 yield one filter each (1x1 cross product)
+			golden: []byte{
+				0x2e, 0x0a, 0x01, 0xc2, 0x11, 0x00, 0x6f, 0x01, 0x00, 0x06, 0x31, 0x31,
+				0x01, 0x01, 0xff, 0x01, 0x02, 0x00, 0x63, 0x24, 0x31, 0x1c, 0x11, 0x0a,
+				0x3c, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0x41, 0x07, 0xd0, 0x0b, 0xb8,
+				0x10, 0x0a, 0x0a, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0x50, 0x03, 0xe8,
+				0x30, 0x06, 0x12, 0x1f, 0x70, 0x28, 0xff, 0x11, 0x0a, 0x3c, 0x00, 0x01,
+				0xff, 0xff, 0xff, 0xff, 0x40, 0x01, 0xbb, 0x10, 0x0a, 0x14, 0x00, 0x00,
+				0xff, 0xff, 0x00, 0x00, 0x51, 0x13, 0x88, 0x17, 0x70, 0x30, 0x11, 0x23,
+				0x0c, 0x11, 0x0a, 0x3c, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0x40, 0x1f,
+				0x90, 0x34, 0x11, 0x60, 0x00, 0x1a, 0x2b, 0x3c, 0x10, 0x0a, 0x1e, 0x00,
+				0x00, 0xff, 0xff, 0x00, 0x00, 0x50, 0x23, 0x28, 0x64, 0x02, 0x06, 0x01,
+				0x00, 0x64, 0x01, 0x00, 0xc8, 0x29, 0x05, 0x01, 0x0a, 0x3c, 0x00, 0x01,
+				0x22, 0x04, 0x01, 0x11, 0x22, 0x32, 0x79, 0x00, 0x20, 0x01, 0x20, 0x41,
+				0x01, 0x01, 0x09, 0x02, 0x20, 0x45, 0x01, 0x01, 0x01, 0x03, 0x03, 0x06,
+				0x00, 0x64, 0x02, 0x03, 0x06, 0x00, 0x32, 0x05, 0x03, 0x06, 0x00, 0xc8,
+				0x04, 0x03, 0x06, 0x00, 0x96, 0x25, 0x09, 0x08, 0x69, 0x6e, 0x74, 0x65,
+				0x72, 0x6e, 0x65, 0x74,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -150,6 +238,9 @@ func TestGoldenBuildGSMPDUSessionEstablishmentAccept(t *testing.T) {
 			var qosRules nasType.QoSRules
 			require.NoError(t, qosRules.UnmarshalBinary(accept.AuthorizedQosRules.GetQosRule()))
 			require.Len(t, qosRules, tc.wantQoSRules)
+			if tc.wantPFsInRule > 0 {
+				require.Len(t, qosRules[1].PacketFilterList, tc.wantPFsInRule)
+			}
 
 			if tc.wantCause == 0 {
 				require.Nil(t, accept.Cause5GSM)

--- a/internal/context/gsm_build_internal_test.go
+++ b/internal/context/gsm_build_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/free5gc/nas"
 	"github.com/free5gc/nas/nasMessage"
+	"github.com/free5gc/nas/nasType"
 	"github.com/free5gc/openapi/models"
 	"github.com/free5gc/util/idgenerator"
 )
@@ -41,6 +42,122 @@ func newGSMTestContext() *SMContext {
 		PacketFilterIDGenerator:      idgenerator.NewGenerator(1, 255),
 		PCCRuleIDToQoSRuleID:         map[string]uint8{},
 		PacketFilterIDToNASPFID:      map[string]uint8{},
+	}
+}
+
+func TestGoldenBuildGSMPDUSessionEstablishmentAccept(t *testing.T) {
+	testCases := []struct {
+		name         string
+		setupContext func() *SMContext
+		wantCause    uint8 // 0 = Cause5GSM IE absent
+		wantQoSRules int
+		golden       []byte
+	}{
+		{
+			name:         "Minimal",
+			setupContext: newGSMTestContext,
+			wantCause:    0,
+			wantQoSRules: 1,
+			golden: []byte{
+				0x2e, 0x0a, 0x01, 0xc2, 0x11, 0x00, 0x09, 0x01, 0x00, 0x06, 0x31, 0x31,
+				0x01, 0x01, 0xff, 0x01, 0x06, 0x01, 0x00, 0x64, 0x01, 0x00, 0xc8, 0x29,
+				0x05, 0x01, 0x0a, 0x3c, 0x00, 0x01, 0x22, 0x04, 0x01, 0x11, 0x22, 0x32,
+				0x79, 0x00, 0x06, 0x01, 0x20, 0x41, 0x01, 0x01, 0x09, 0x25, 0x09, 0x08,
+				0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74,
+			},
+		},
+		{
+			name: "Full",
+			setupContext: func() *SMContext {
+				smContext := newGSMTestContext()
+				smContext.EstAcceptCause5gSMValue = nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed
+				// exactly ONE PCC rule / ONE additional QoS flow: two or more
+				// makes the golden unstable (map iteration + rule ID allocation)
+				smContext.PCCRules = map[string]*PCCRule{
+					"PccRuleId-1": {
+						PccRule: &models.PccRule{
+							PccRuleId:  "PccRuleId-1",
+							Precedence: 200,
+							FlowInfos: []models.FlowInformation{{
+								FlowDescription: "permit out ip from any to assigned",
+								PackFiltId:      "PackFiltId-1",
+								FlowDirection:   models.FlowDirection_BIDIRECTIONAL,
+							}},
+						},
+						QFI: 2,
+					},
+				}
+				smContext.AdditionalQosFlows = map[uint8]*QoSFlow{
+					2: NewQoSFlow(2, &models.QosData{
+						Var5qi: 9,
+						Arp: &models.Arp{
+							PriorityLevel: 8,
+							PreemptCap:    models.PreemptionCapability_NOT_PREEMPT,
+							PreemptVuln:   models.PreemptionVulnerability_NOT_PREEMPTABLE,
+						},
+					}),
+				}
+				smContext.ProtocolConfigurationOptions = &ProtocolConfigurationOptions{
+					DNSIPv4Request:     true,
+					IPv4LinkMTURequest: true,
+				}
+				smContext.DNNInfo = &SnssaiSmfDnnInfo{
+					DNS: DNS{IPv4Addr: net.ParseIP("8.8.8.8").To4()},
+				}
+				return smContext
+			},
+			wantCause:    nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed,
+			wantQoSRules: 2,
+			golden: []byte{
+				0x2e, 0x0a, 0x01, 0xc2, 0x11, 0x00, 0x12, 0x01, 0x00, 0x06, 0x31, 0x31,
+				0x01, 0x01, 0xff, 0x01, 0x02, 0x00, 0x06, 0x21, 0x31, 0x01, 0x01, 0xc8,
+				0x02, 0x06, 0x01, 0x00, 0x64, 0x01, 0x00, 0xc8, 0x59, 0x32, 0x29, 0x05,
+				0x01, 0x0a, 0x3c, 0x00, 0x01, 0x22, 0x04, 0x01, 0x11, 0x22, 0x32, 0x79,
+				0x00, 0x0c, 0x01, 0x20, 0x41, 0x01, 0x01, 0x09, 0x02, 0x20, 0x41, 0x01,
+				0x01, 0x09, 0x7b, 0x00, 0x0d, 0x80, 0x00, 0x0d, 0x04, 0x08, 0x08, 0x08,
+				0x08, 0x00, 0x10, 0x02, 0x05, 0x78, 0x25, 0x09, 0x08, 0x69, 0x6e, 0x74,
+				0x65, 0x72, 0x6e, 0x65, 0x74,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			smContext := tc.setupContext()
+
+			got, err := BuildGSMPDUSessionEstablishmentAccept(smContext)
+			require.NoError(t, err)
+
+			// double-encode guard needs a fresh context: the builder allocates
+			// QoS rule IDs from QoSRuleIDGenerator on every call
+			got2, err := BuildGSMPDUSessionEstablishmentAccept(tc.setupContext())
+			require.NoError(t, err)
+			require.Equal(t, got, got2)
+
+			require.Equal(t, tc.golden, got)
+
+			m := nas.NewMessage()
+			golden := tc.golden
+			require.NoError(t, m.GsmMessageDecode(&golden))
+			accept := m.PDUSessionEstablishmentAccept
+			require.Equal(t, nas.MsgTypePDUSessionEstablishmentAccept, m.GsmHeader.GetMessageType())
+			require.Equal(t, uint8(1), accept.GetPTI())
+			require.Equal(t, uint8(10), accept.GetPDUSessionID())
+
+			addr := accept.PDUAddress.GetPDUAddressInformation()
+			require.Equal(t, []byte(net.ParseIP("10.60.0.1").To4()), addr[:4])
+
+			var qosRules nasType.QoSRules
+			require.NoError(t, qosRules.UnmarshalBinary(accept.AuthorizedQosRules.GetQosRule()))
+			require.Len(t, qosRules, tc.wantQoSRules)
+
+			if tc.wantCause == 0 {
+				require.Nil(t, accept.Cause5GSM)
+			} else {
+				require.NotNil(t, accept.Cause5GSM)
+				require.Equal(t, tc.wantCause, accept.Cause5GSM.GetCauseValue())
+			}
+		})
 	}
 }
 

--- a/internal/context/gsm_build_internal_test.go
+++ b/internal/context/gsm_build_internal_test.go
@@ -1,0 +1,184 @@
+package context
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/free5gc/nas"
+	"github.com/free5gc/nas/nasMessage"
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/util/idgenerator"
+)
+
+const testSessRuleID = "SessRuleId-1"
+
+// newGSMTestContext builds a minimal deterministic SMContext for golden tests.
+// It intentionally does NOT use NewSMContext: that would touch the global
+// TeidGenerator (nil in unit tests) and the smContextPool.
+func newGSMTestContext() *SMContext {
+	sessRule := NewSessionRule(&models.SessionRule{
+		AuthSessAmbr: &models.Ambr{Uplink: "200 Kbps", Downlink: "100 Kbps"},
+		AuthDefQos:   &models.AuthorizedDefaultQos{Var5qi: 9, Arp: &models.Arp{PriorityLevel: 8}},
+		SessRuleId:   testSessRuleID,
+	})
+	return &SMContext{
+		SmfPduSessionSmContextCreateData: &models.SmfPduSessionSmContextCreateData{
+			Dnn:    "internet",
+			SNssai: &models.Snssai{Sst: 1, Sd: "112232"},
+			AnType: models.AccessType__3_GPP_ACCESS,
+		},
+		PDUSessionID:                 10,
+		Pti:                          1,
+		SelectedPDUSessionType:       nasMessage.PDUSessionTypeIPv4,
+		PDUAddress:                   net.ParseIP("10.60.0.1").To4(),
+		ProtocolConfigurationOptions: &ProtocolConfigurationOptions{},
+		SessionRules:                 map[string]*SessionRule{testSessRuleID: sessRule},
+		SelectedSessionRuleID:        testSessRuleID,
+		defRuleID:                    1,
+		QoSRuleIDGenerator:           idgenerator.NewGenerator(2, 255), // 1 is taken by defRuleID
+		PacketFilterIDGenerator:      idgenerator.NewGenerator(1, 255),
+		PCCRuleIDToQoSRuleID:         map[string]uint8{},
+		PacketFilterIDToNASPFID:      map[string]uint8{},
+	}
+}
+
+func TestGoldenBuildGSMPDUSessionEstablishmentReject(t *testing.T) {
+	smContext := newGSMTestContext()
+
+	golden := []byte{0x2e, 0x0a, 0x01, 0xc3, 0x26}
+
+	got, err := BuildGSMPDUSessionEstablishmentReject(smContext, nasMessage.Cause5GSMNetworkFailure)
+	require.NoError(t, err)
+
+	// double-encode guard: same fixture must yield identical bytes
+	got2, err := BuildGSMPDUSessionEstablishmentReject(smContext, nasMessage.Cause5GSMNetworkFailure)
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+
+	require.Equal(t, golden, got)
+
+	// decode-back check
+	m := nas.NewMessage()
+	require.NoError(t, m.GsmMessageDecode(&golden))
+	require.Equal(t, nas.MsgTypePDUSessionEstablishmentReject, m.GsmHeader.GetMessageType())
+	require.Equal(t, uint8(1), m.PDUSessionEstablishmentReject.GetPTI())
+	require.Equal(t, uint8(10), m.PDUSessionEstablishmentReject.GetPDUSessionID())
+	require.Equal(t, nasMessage.Cause5GSMNetworkFailure, m.PDUSessionEstablishmentReject.GetCauseValue())
+}
+
+func TestGoldenBuildGSMPDUSessionReleaseCommand(t *testing.T) {
+	testCases := []struct {
+		name            string
+		isTriggeredByUE bool
+		wantPTI         uint8
+		golden          []byte
+	}{
+		{
+			name:            "TriggeredByUE",
+			isTriggeredByUE: true,
+			wantPTI:         1,
+			golden:          []byte{0x2e, 0x0a, 0x01, 0xd3, 0x24},
+		},
+		{
+			name:            "TriggeredByNetwork",
+			isTriggeredByUE: false,
+			wantPTI:         0,
+			golden:          []byte{0x2e, 0x0a, 0x00, 0xd3, 0x24},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			smContext := newGSMTestContext()
+
+			got, err := BuildGSMPDUSessionReleaseCommand(
+				smContext, nasMessage.Cause5GSMRegularDeactivation, tc.isTriggeredByUE)
+			require.NoError(t, err)
+
+			got2, err := BuildGSMPDUSessionReleaseCommand(
+				smContext, nasMessage.Cause5GSMRegularDeactivation, tc.isTriggeredByUE)
+			require.NoError(t, err)
+			require.Equal(t, got, got2)
+
+			require.Equal(t, tc.golden, got)
+
+			m := nas.NewMessage()
+			golden := tc.golden
+			require.NoError(t, m.GsmMessageDecode(&golden))
+			require.Equal(t, nas.MsgTypePDUSessionReleaseCommand, m.GsmHeader.GetMessageType())
+			require.Equal(t, tc.wantPTI, m.PDUSessionReleaseCommand.GetPTI())
+			require.Equal(t, uint8(10), m.PDUSessionReleaseCommand.GetPDUSessionID())
+			require.Equal(t, nasMessage.Cause5GSMRegularDeactivation,
+				m.PDUSessionReleaseCommand.GetCauseValue())
+		})
+	}
+}
+
+func TestGoldenBuildGSMPDUSessionModificationCommand(t *testing.T) {
+	smContext := newGSMTestContext()
+
+	golden := []byte{0x2e, 0x0a, 0x01, 0xcb}
+
+	got, err := BuildGSMPDUSessionModificationCommand(smContext)
+	require.NoError(t, err)
+
+	got2, err := BuildGSMPDUSessionModificationCommand(smContext)
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+
+	require.Equal(t, golden, got)
+
+	m := nas.NewMessage()
+	require.NoError(t, m.GsmMessageDecode(&golden))
+	require.Equal(t, nas.MsgTypePDUSessionModificationCommand, m.GsmHeader.GetMessageType())
+	require.Equal(t, uint8(1), m.PDUSessionModificationCommand.GetPTI())
+	require.Equal(t, uint8(10), m.PDUSessionModificationCommand.GetPDUSessionID())
+}
+
+func TestGoldenBuildGSMPDUSessionReleaseReject(t *testing.T) {
+	smContext := newGSMTestContext()
+
+	golden := []byte{0x2e, 0x0a, 0x01, 0xd2, 0x1f}
+
+	got, err := BuildGSMPDUSessionReleaseReject(smContext)
+	require.NoError(t, err)
+
+	got2, err := BuildGSMPDUSessionReleaseReject(smContext)
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+
+	require.Equal(t, golden, got)
+
+	m := nas.NewMessage()
+	require.NoError(t, m.GsmMessageDecode(&golden))
+	require.Equal(t, nas.MsgTypePDUSessionReleaseReject, m.GsmHeader.GetMessageType())
+	require.Equal(t, uint8(1), m.PDUSessionReleaseReject.GetPTI())
+	require.Equal(t, uint8(10), m.PDUSessionReleaseReject.GetPDUSessionID())
+	require.Equal(t, nasMessage.Cause5GSMRequestRejectedUnspecified,
+		m.PDUSessionReleaseReject.GetCauseValue())
+}
+
+func TestGoldenBuildGSMPDUSessionModificationReject(t *testing.T) {
+	smContext := newGSMTestContext()
+
+	golden := []byte{0x2e, 0x0a, 0x01, 0xca, 0x61}
+
+	got, err := BuildGSMPDUSessionModificationReject(smContext)
+	require.NoError(t, err)
+
+	got2, err := BuildGSMPDUSessionModificationReject(smContext)
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+
+	require.Equal(t, golden, got)
+
+	m := nas.NewMessage()
+	require.NoError(t, m.GsmMessageDecode(&golden))
+	require.Equal(t, nas.MsgTypePDUSessionModificationReject, m.GsmHeader.GetMessageType())
+	require.Equal(t, uint8(1), m.PDUSessionModificationReject.GetPTI())
+	require.Equal(t, uint8(10), m.PDUSessionModificationReject.GetPDUSessionID())
+	require.Equal(t, nasMessage.Cause5GSMMessageTypeNonExistentOrNotImplemented,
+		m.PDUSessionModificationReject.GetCauseValue())
+}

--- a/internal/context/ngap_build_internal_test.go
+++ b/internal/context/ngap_build_internal_test.go
@@ -169,11 +169,34 @@ func TestGoldenBuildPDUSessionResourceSetupRequestTransfer(t *testing.T) {
 		}
 	}
 
+	newGBRSetupContext := func() *SMContext {
+		smContext := newSetupContext(false)()
+		// exactly ONE additional flow (map iteration order!) with a standard
+		// GBR 5QI: exercises BuildNgapQosFlowSetupRequestItem and the
+		// GBRQosInformation branch (bitrate-string conversion included)
+		smContext.AdditionalQosFlows = map[uint8]*QoSFlow{
+			2: NewQoSFlow(2, &models.QosData{
+				Var5qi:  1,
+				GbrDl:   "100 Mbps",
+				GbrUl:   "50 Mbps",
+				MaxbrDl: "200 Mbps",
+				MaxbrUl: "150 Mbps",
+				Arp: &models.Arp{
+					PriorityLevel: 8,
+					PreemptCap:    models.PreemptionCapability_NOT_PREEMPT,
+					PreemptVuln:   models.PreemptionVulnerability_NOT_PREEMPTABLE,
+				},
+			}),
+		}
+		return smContext
+	}
+
 	testCases := []struct {
 		name           string
 		setupContext   func() *SMContext
 		withUpSecurity bool
 		wantIEs        int
+		wantQosFlows   int
 		golden         []byte
 	}{
 		{
@@ -181,6 +204,7 @@ func TestGoldenBuildPDUSessionResourceSetupRequestTransfer(t *testing.T) {
 			setupContext:   newSetupContext(false),
 			withUpSecurity: false,
 			wantIEs:        5,
+			wantQosFlows:   1,
 			golden: []byte{
 				0x00, 0x00, 0x05, 0x00, 0x82, 0x00, 0x08, 0x08, 0x01, 0x86, 0xa0, 0x20,
 				0x03, 0x0d, 0x40, 0x00, 0x8b, 0x00, 0x0a, 0x01, 0xf0, 0x7f, 0x00, 0x00,
@@ -194,6 +218,7 @@ func TestGoldenBuildPDUSessionResourceSetupRequestTransfer(t *testing.T) {
 			setupContext:   newSetupContext(true),
 			withUpSecurity: true,
 			wantIEs:        6,
+			wantQosFlows:   1,
 			golden: []byte{
 				0x00, 0x00, 0x06, 0x00, 0x82, 0x00, 0x08, 0x08, 0x01, 0x86, 0xa0, 0x20,
 				0x03, 0x0d, 0x40, 0x00, 0x8b, 0x00, 0x0a, 0x01, 0xf0, 0x7f, 0x00, 0x00,
@@ -201,6 +226,23 @@ func TestGoldenBuildPDUSessionResourceSetupRequestTransfer(t *testing.T) {
 				0x00, 0x00, 0x08, 0x00, 0x00, 0x01, 0x02, 0x00, 0x86, 0x00, 0x01, 0x00,
 				0x00, 0x88, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x09, 0x1c, 0x00, 0x00,
 				0x8a, 0x00, 0x02, 0x40, 0x20,
+			},
+		},
+		{
+			name:           "WithGBRAdditionalQosFlow",
+			setupContext:   newGBRSetupContext,
+			withUpSecurity: false,
+			wantIEs:        5,
+			wantQosFlows:   2,
+			golden: []byte{
+				0x00, 0x00, 0x05, 0x00, 0x82, 0x00, 0x08, 0x08, 0x01, 0x86, 0xa0, 0x20,
+				0x03, 0x0d, 0x40, 0x00, 0x8b, 0x00, 0x0a, 0x01, 0xf0, 0x7f, 0x00, 0x00,
+				0x08, 0x00, 0x00, 0x01, 0x01, 0x00, 0x7e, 0x40, 0x0a, 0x00, 0x1f, 0x7f,
+				0x00, 0x00, 0x08, 0x00, 0x00, 0x01, 0x02, 0x00, 0x86, 0x00, 0x01, 0x00,
+				0x00, 0x88, 0x00, 0x21, 0x04, 0x01, 0x00, 0x00, 0x09, 0x1c, 0x00, 0x24,
+				0x00, 0x00, 0x01, 0x1c, 0x00, 0x60, 0x0b, 0xeb, 0xc2, 0x00, 0x30, 0x08,
+				0xf0, 0xd1, 0x80, 0x30, 0x05, 0xf5, 0xe1, 0x00, 0x30, 0x02, 0xfa, 0xf0,
+				0x80,
 			},
 		},
 	}
@@ -222,15 +264,30 @@ func TestGoldenBuildPDUSessionResourceSetupRequestTransfer(t *testing.T) {
 
 			var gotTEID aper.OctetString
 			var gotSecurity *ngapType.SecurityIndication
+			var gotQosList *ngapType.QosFlowSetupRequestList
 			for _, ie := range decoded.ProtocolIEs.List {
 				switch ie.Id.Value {
 				case ngapType.ProtocolIEIDULNGUUPTNLInformation:
 					gotTEID = ie.Value.ULNGUUPTNLInformation.GTPTunnel.GTPTEID.Value
 				case ngapType.ProtocolIEIDSecurityIndication:
 					gotSecurity = ie.Value.SecurityIndication
+				case ngapType.ProtocolIEIDQosFlowSetupRequestList:
+					gotQosList = ie.Value.QosFlowSetupRequestList
 				}
 			}
 			require.Equal(t, aper.OctetString{0x00, 0x00, 0x01, 0x01}, gotTEID)
+			require.NotNil(t, gotQosList)
+			require.Len(t, gotQosList.List, tc.wantQosFlows)
+			if tc.wantQosFlows > 1 {
+				gbrItem := gotQosList.List[1]
+				require.Equal(t, int64(2), gbrItem.QosFlowIdentifier.Value)
+				gbrInfo := gbrItem.QosFlowLevelQosParameters.GBRQosInformation
+				require.NotNil(t, gbrInfo)
+				require.Equal(t, int64(200000000), gbrInfo.MaximumFlowBitRateDL.Value)
+				require.Equal(t, int64(150000000), gbrInfo.MaximumFlowBitRateUL.Value)
+				require.Equal(t, int64(100000000), gbrInfo.GuaranteedFlowBitRateDL.Value)
+				require.Equal(t, int64(50000000), gbrInfo.GuaranteedFlowBitRateUL.Value)
+			}
 			if tc.withUpSecurity {
 				require.NotNil(t, gotSecurity)
 				require.Equal(t, ngapType.IntegrityProtectionIndicationPresentRequired,

--- a/internal/context/ngap_build_internal_test.go
+++ b/internal/context/ngap_build_internal_test.go
@@ -147,3 +147,261 @@ func TestGoldenBuildPDUSessionResourceModifyConfirmTransfer(t *testing.T) {
 	require.Equal(t, []byte(net.ParseIP("192.168.179.1").To4()),
 		decoded.ULNGUUPTNLInformation.GTPTunnel.TransportLayerAddress.Value.Bytes)
 }
+
+func TestGoldenBuildPDUSessionResourceSetupRequestTransfer(t *testing.T) {
+	newSetupContext := func(withUpSecurity bool) func() *SMContext {
+		return func() *SMContext {
+			smContext := newGSMTestContext()
+			smContext.Tunnel = newTestUPTunnel()
+			// fixed values: NewSMContext would pull these from the global
+			// TeidGenerator, which is test-order dependent
+			smContext.LocalULTeid = 0x00000101
+			smContext.LocalULTeidForSplitPDUSession = 0x00000102
+			if withUpSecurity {
+				smContext.UpSecurity = &models.UpSecurity{
+					UpIntegr: models.UpIntegrity_REQUIRED,
+					UpConfid: models.UpConfidentiality_REQUIRED,
+				}
+				maxUERate := models.MaxIntegrityProtectedDataRate_MAX_UE_RATE
+				smContext.MaximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink = maxUERate
+			}
+			return smContext
+		}
+	}
+
+	testCases := []struct {
+		name           string
+		setupContext   func() *SMContext
+		withUpSecurity bool
+		wantIEs        int
+		golden         []byte
+	}{
+		{
+			name:           "WithoutUpSecurity",
+			setupContext:   newSetupContext(false),
+			withUpSecurity: false,
+			wantIEs:        5,
+			golden: []byte{
+				0x00, 0x00, 0x05, 0x00, 0x82, 0x00, 0x08, 0x08, 0x01, 0x86, 0xa0, 0x20,
+				0x03, 0x0d, 0x40, 0x00, 0x8b, 0x00, 0x0a, 0x01, 0xf0, 0x7f, 0x00, 0x00,
+				0x08, 0x00, 0x00, 0x01, 0x01, 0x00, 0x7e, 0x40, 0x0a, 0x00, 0x1f, 0x7f,
+				0x00, 0x00, 0x08, 0x00, 0x00, 0x01, 0x02, 0x00, 0x86, 0x00, 0x01, 0x00,
+				0x00, 0x88, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x09, 0x1c, 0x00,
+			},
+		},
+		{
+			name:           "WithUpSecurity",
+			setupContext:   newSetupContext(true),
+			withUpSecurity: true,
+			wantIEs:        6,
+			golden: []byte{
+				0x00, 0x00, 0x06, 0x00, 0x82, 0x00, 0x08, 0x08, 0x01, 0x86, 0xa0, 0x20,
+				0x03, 0x0d, 0x40, 0x00, 0x8b, 0x00, 0x0a, 0x01, 0xf0, 0x7f, 0x00, 0x00,
+				0x08, 0x00, 0x00, 0x01, 0x01, 0x00, 0x7e, 0x40, 0x0a, 0x00, 0x1f, 0x7f,
+				0x00, 0x00, 0x08, 0x00, 0x00, 0x01, 0x02, 0x00, 0x86, 0x00, 0x01, 0x00,
+				0x00, 0x88, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x09, 0x1c, 0x00, 0x00,
+				0x8a, 0x00, 0x02, 0x40, 0x20,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BuildPDUSessionResourceSetupRequestTransfer(tc.setupContext())
+			require.NoError(t, err)
+
+			got2, err := BuildPDUSessionResourceSetupRequestTransfer(tc.setupContext())
+			require.NoError(t, err)
+			require.Equal(t, got, got2)
+
+			require.Equal(t, tc.golden, got)
+
+			var decoded ngapType.PDUSessionResourceSetupRequestTransfer
+			require.NoError(t, aper.UnmarshalWithParams(tc.golden, &decoded, "valueExt"))
+			require.Len(t, decoded.ProtocolIEs.List, tc.wantIEs)
+
+			var gotTEID aper.OctetString
+			var gotSecurity *ngapType.SecurityIndication
+			for _, ie := range decoded.ProtocolIEs.List {
+				switch ie.Id.Value {
+				case ngapType.ProtocolIEIDULNGUUPTNLInformation:
+					gotTEID = ie.Value.ULNGUUPTNLInformation.GTPTunnel.GTPTEID.Value
+				case ngapType.ProtocolIEIDSecurityIndication:
+					gotSecurity = ie.Value.SecurityIndication
+				}
+			}
+			require.Equal(t, aper.OctetString{0x00, 0x00, 0x01, 0x01}, gotTEID)
+			if tc.withUpSecurity {
+				require.NotNil(t, gotSecurity)
+				require.Equal(t, ngapType.IntegrityProtectionIndicationPresentRequired,
+					gotSecurity.IntegrityProtectionIndication.Value)
+				require.Equal(t, ngapType.ConfidentialityProtectionIndicationPresentRequired,
+					gotSecurity.ConfidentialityProtectionIndication.Value)
+				require.NotNil(t, gotSecurity.MaximumIntegrityProtectedDataRateUL)
+				require.Equal(t, ngapType.MaximumIntegrityProtectedDataRatePresentMaximumUERate,
+					gotSecurity.MaximumIntegrityProtectedDataRateUL.Value)
+			} else {
+				require.Nil(t, gotSecurity)
+			}
+		})
+	}
+}
+
+func TestGoldenBuildPathSwitchRequestAcknowledgeTransfer(t *testing.T) {
+	newAckContext := func(sameAsLocalStored bool) func() *SMContext {
+		return func() *SMContext {
+			smContext := newGSMTestContext()
+			smContext.Tunnel = newTestUPTunnel()
+			smContext.UpSecurityFromPathSwitchRequestSameAsLocalStored = sameAsLocalStored
+			if !sameAsLocalStored {
+				// the false (zero-value!) branch dereferences ctx.UpSecurity:
+				// it MUST be set or the builder panics
+				smContext.UpSecurity = &models.UpSecurity{
+					UpIntegr: models.UpIntegrity_REQUIRED,
+					UpConfid: models.UpConfidentiality_REQUIRED,
+				}
+				maxUERate := models.MaxIntegrityProtectedDataRate_MAX_UE_RATE
+				smContext.MaximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink = maxUERate
+			}
+			return smContext
+		}
+	}
+
+	testCases := []struct {
+		name              string
+		setupContext      func() *SMContext
+		wantSecurityIndic bool
+		golden            []byte
+	}{
+		{
+			name:              "SecuritySameAsLocalStored",
+			setupContext:      newAckContext(true),
+			wantSecurityIndic: false,
+			golden: []byte{
+				0x40, 0x1f, 0x7f, 0x00, 0x00, 0x08, 0x00, 0x00, 0x10, 0x01,
+			},
+		},
+		{
+			name:              "SecurityMismatch",
+			setupContext:      newAckContext(false),
+			wantSecurityIndic: true,
+			golden: []byte{
+				0x60, 0x1f, 0x7f, 0x00, 0x00, 0x08, 0x00, 0x00, 0x10, 0x01, 0x40, 0x20,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BuildPathSwitchRequestAcknowledgeTransfer(tc.setupContext())
+			require.NoError(t, err)
+
+			got2, err := BuildPathSwitchRequestAcknowledgeTransfer(tc.setupContext())
+			require.NoError(t, err)
+			require.Equal(t, got, got2)
+
+			require.Equal(t, tc.golden, got)
+
+			var decoded ngapType.PathSwitchRequestAcknowledgeTransfer
+			require.NoError(t, aper.UnmarshalWithParams(tc.golden, &decoded, "valueExt"))
+			require.NotNil(t, decoded.ULNGUUPTNLInformation)
+			gtpTunnel := decoded.ULNGUUPTNLInformation.GTPTunnel
+			require.NotNil(t, gtpTunnel)
+			require.Equal(t, aper.OctetString{0x00, 0x00, 0x10, 0x01}, gtpTunnel.GTPTEID.Value)
+			require.Equal(t, []byte(net.ParseIP("127.0.0.8").To4()),
+				gtpTunnel.TransportLayerAddress.Value.Bytes)
+			if tc.wantSecurityIndic {
+				require.NotNil(t, decoded.SecurityIndication)
+				require.Equal(t, ngapType.IntegrityProtectionIndicationPresentRequired,
+					decoded.SecurityIndication.IntegrityProtectionIndication.Value)
+			} else {
+				require.Nil(t, decoded.SecurityIndication)
+			}
+		})
+	}
+}
+
+func TestGoldenBuildHandoverCommandTransfer(t *testing.T) {
+	newDirectContext := func() *SMContext {
+		smContext := newGSMTestContext()
+		// zero value of DLForwardingType is IndirectForwarding: ALWAYS set it
+		smContext.DLForwardingType = DirectForwarding
+		smContext.DLDirectForwardingTunnel = &ngapType.UPTransportLayerInformation{
+			Present: ngapType.UPTransportLayerInformationPresentGTPTunnel,
+			GTPTunnel: &ngapType.GTPTunnel{
+				TransportLayerAddress: ngapType.TransportLayerAddress{
+					Value: aper.BitString{
+						Bytes:     net.ParseIP("127.0.0.10").To4(),
+						BitLength: 32,
+					},
+				},
+				GTPTEID: ngapType.GTPTEID{Value: aper.OctetString{0x00, 0x00, 0x01, 0x04}},
+			},
+		}
+		return smContext
+	}
+	newIndirectContext := func() *SMContext {
+		smContext := newGSMTestContext()
+		smContext.DLForwardingType = IndirectForwarding
+		smContext.Tunnel = newTestUPTunnel() // indirect branch reads the N3 IP from Tunnel's ANUPF
+		node2 := NewDataPathNode()
+		node2.UpLinkTunnel.TEID = 0x1002
+		smContext.IndirectForwardingTunnel = &DataPath{FirstDPNode: node2}
+		return smContext
+	}
+
+	testCases := []struct {
+		name         string
+		setupContext func() *SMContext
+		wantTEID     aper.OctetString
+		wantIP       string
+		golden       []byte
+	}{
+		{
+			name:         "DirectForwarding",
+			setupContext: newDirectContext,
+			wantTEID:     aper.OctetString{0x00, 0x00, 0x01, 0x04},
+			wantIP:       "127.0.0.10",
+			golden: []byte{
+				0x60, 0x0f, 0x80, 0x7f, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x01, 0x04, 0x00,
+				0x12,
+			},
+		},
+		{
+			name:         "IndirectForwarding",
+			setupContext: newIndirectContext,
+			wantTEID:     aper.OctetString{0x00, 0x00, 0x10, 0x02},
+			wantIP:       "127.0.0.8",
+			golden: []byte{
+				0x60, 0x0f, 0x80, 0x7f, 0x00, 0x00, 0x08, 0x00, 0x00, 0x10, 0x02, 0x00,
+				0x12,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BuildHandoverCommandTransfer(tc.setupContext())
+			require.NoError(t, err)
+
+			got2, err := BuildHandoverCommandTransfer(tc.setupContext())
+			require.NoError(t, err)
+			require.Equal(t, got, got2)
+
+			require.Equal(t, tc.golden, got)
+
+			var decoded ngapType.HandoverCommandTransfer
+			require.NoError(t, aper.UnmarshalWithParams(tc.golden, &decoded, "valueExt"))
+			require.NotNil(t, decoded.DLForwardingUPTNLInformation)
+			gtpTunnel := decoded.DLForwardingUPTNLInformation.GTPTunnel
+			require.NotNil(t, gtpTunnel)
+			require.Equal(t, tc.wantTEID, gtpTunnel.GTPTEID.Value)
+			require.Equal(t, []byte(net.ParseIP(tc.wantIP).To4()),
+				gtpTunnel.TransportLayerAddress.Value.Bytes)
+			require.NotNil(t, decoded.QosFlowToBeForwardedList)
+			require.Len(t, decoded.QosFlowToBeForwardedList.List, 1)
+			require.Equal(t, int64(DefaultNonGBR5QI),
+				decoded.QosFlowToBeForwardedList.List[0].QosFlowIdentifier.Value)
+		})
+	}
+}

--- a/internal/context/ngap_build_internal_test.go
+++ b/internal/context/ngap_build_internal_test.go
@@ -1,0 +1,149 @@
+package context
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap/ngapType"
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/pfcp/pfcpType"
+	"github.com/free5gc/smf/pkg/factory"
+)
+
+// newTestUPTunnel builds a deterministic single-path UPTunnel: exactly one
+// default data path so DataPathPool map iteration cannot affect the output.
+func newTestUPTunnel() *UPTunnel {
+	upf := NewUPF(
+		&pfcpType.NodeID{NodeIdType: pfcpType.NodeIdTypeIpv4Address, IP: net.ParseIP("192.168.179.1").To4()},
+		[]*factory.InterfaceUpfInfoItem{{
+			InterfaceType:    models.UpInterfaceType_N3,
+			Endpoints:        []string{"127.0.0.8"},
+			NetworkInstances: []string{"internet"},
+		}})
+	node := NewDataPathNode() // non-nil Up/DownLinkTunnel
+	node.UPF = upf
+	node.UpLinkTunnel.TEID = 0x1001
+	dp := NewDataPath()
+	dp.FirstDPNode = node
+	dp.IsDefaultPath = true
+	dp.Activated = true
+	tunnel := NewUPTunnel()
+	tunnel.DataPathPool[1] = dp // fixed key; PathID is never encoded
+	return tunnel
+}
+
+func TestGoldenBuildPathSwitchRequestUnsuccessfulTransfer(t *testing.T) {
+	golden := []byte{0x00, 0x00}
+
+	got, err := BuildPathSwitchRequestUnsuccessfulTransfer(
+		ngapType.CausePresentRadioNetwork, ngapType.CauseRadioNetworkPresentUnspecified)
+	require.NoError(t, err)
+
+	// double-encode guard
+	got2, err := BuildPathSwitchRequestUnsuccessfulTransfer(
+		ngapType.CausePresentRadioNetwork, ngapType.CauseRadioNetworkPresentUnspecified)
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+
+	require.Equal(t, golden, got)
+
+	// decode-back check
+	var decoded ngapType.PathSwitchRequestUnsuccessfulTransfer
+	require.NoError(t, aper.UnmarshalWithParams(golden, &decoded, "valueExt"))
+	require.Equal(t, ngapType.CausePresentRadioNetwork, decoded.Cause.Present)
+	require.NotNil(t, decoded.Cause.RadioNetwork)
+	require.Equal(t, ngapType.CauseRadioNetworkPresentUnspecified, decoded.Cause.RadioNetwork.Value)
+}
+
+func TestGoldenBuildPDUSessionResourceReleaseCommandTransfer(t *testing.T) {
+	golden := []byte{0x10}
+
+	got, err := BuildPDUSessionResourceReleaseCommandTransfer(&SMContext{}) // ctx is unused
+	require.NoError(t, err)
+
+	got2, err := BuildPDUSessionResourceReleaseCommandTransfer(&SMContext{})
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+
+	require.Equal(t, golden, got)
+
+	var decoded ngapType.PDUSessionResourceReleaseCommandTransfer
+	require.NoError(t, aper.UnmarshalWithParams(golden, &decoded, "valueExt"))
+	require.Equal(t, ngapType.CausePresentNas, decoded.Cause.Present)
+	require.NotNil(t, decoded.Cause.Nas)
+	require.Equal(t, ngapType.CauseNasPresentNormalRelease, decoded.Cause.Nas.Value)
+}
+
+func TestGoldenBuildPDUSessionResourceModifyRequestTransfer(t *testing.T) {
+	newModifyContext := func() *SMContext {
+		smContext := newGSMTestContext()
+		// exactly ONE flow: QosFlowAddOrModifyRequestList has aper tag sizeLB:1,
+		// and two or more map entries would make the encoding order unstable
+		smContext.AdditionalQosFlows = map[uint8]*QoSFlow{
+			2: NewQoSFlow(2, &models.QosData{
+				Var5qi: 9,
+				Arp: &models.Arp{
+					PriorityLevel: 8,
+					PreemptCap:    models.PreemptionCapability_NOT_PREEMPT,
+					PreemptVuln:   models.PreemptionVulnerability_NOT_PREEMPTABLE,
+				},
+			}),
+		}
+		return smContext
+	}
+
+	golden := []byte{0x00, 0x00, 0x01, 0x00, 0x87, 0x00, 0x07, 0x01, 0x01, 0x00, 0x00, 0x09, 0x1c, 0x00}
+
+	got, err := BuildPDUSessionResourceModifyRequestTransfer(newModifyContext())
+	require.NoError(t, err)
+
+	got2, err := BuildPDUSessionResourceModifyRequestTransfer(newModifyContext())
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+
+	require.Equal(t, golden, got)
+
+	var decoded ngapType.PDUSessionResourceModifyRequestTransfer
+	require.NoError(t, aper.UnmarshalWithParams(golden, &decoded, "valueExt"))
+	require.Len(t, decoded.ProtocolIEs.List, 1)
+	qosList := decoded.ProtocolIEs.List[0].Value.QosFlowAddOrModifyRequestList
+	require.NotNil(t, qosList)
+	require.Len(t, qosList.List, 1)
+	require.Equal(t, int64(2), qosList.List[0].QosFlowIdentifier.Value)
+}
+
+func TestGoldenBuildPDUSessionResourceModifyConfirmTransfer(t *testing.T) {
+	newConfirmTunnel := func() *UPTunnel {
+		tunnel := newTestUPTunnel()
+		node := tunnel.DataPathPool.GetDefaultPath().FirstDPNode
+		// Precedence must not be 255 (default flow is skipped by the builder)
+		node.DownLinkTunnel.PDR = &PDR{
+			Precedence: 100,
+			QER:        []*QER{{QFI: pfcpType.QFI{QFI: 2}}},
+		}
+		return tunnel
+	}
+
+	golden := []byte{0x00, 0x00, 0x40, 0x3e, 0xc0, 0xa8, 0xb3, 0x01, 0x00, 0x00, 0x01, 0x03}
+
+	got, err := BuildPDUSessionResourceModifyConfirmTransfer(newGSMTestContext(), newConfirmTunnel(), 0x00000103)
+	require.NoError(t, err)
+
+	got2, err := BuildPDUSessionResourceModifyConfirmTransfer(newGSMTestContext(), newConfirmTunnel(), 0x00000103)
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+
+	require.Equal(t, golden, got)
+
+	var decoded ngapType.PDUSessionResourceModifyConfirmTransfer
+	require.NoError(t, aper.UnmarshalWithParams(golden, &decoded, "valueExt"))
+	require.Len(t, decoded.QosFlowModifyConfirmList.List, 1)
+	require.Equal(t, int64(2), decoded.QosFlowModifyConfirmList.List[0].QosFlowIdentifier.Value)
+	require.NotNil(t, decoded.ULNGUUPTNLInformation.GTPTunnel)
+	require.Equal(t, aper.OctetString{0x00, 0x00, 0x01, 0x03}, decoded.ULNGUUPTNLInformation.GTPTunnel.GTPTEID.Value)
+	require.Equal(t, []byte(net.ParseIP("192.168.179.1").To4()),
+		decoded.ULNGUUPTNLInformation.GTPTunnel.TransportLayerAddress.Value.Bytes)
+}

--- a/internal/sbi/consumer/openapi_golden_test.go
+++ b/internal/sbi/consumer/openapi_golden_test.go
@@ -1,0 +1,137 @@
+package consumer_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/free5gc/openapi"
+	"github.com/free5gc/openapi/models"
+)
+
+const (
+	testN1ContentID   = "GSM_NAS"
+	testN2ContentID   = "N2SmInformation"
+	jsonMediaType     = "application/json"
+	multipartCTPrefix = `multipart/related; boundary="`
+)
+
+// goldenN1N2ReqDataJSON is the golden JSON encoding of newTestN1N2MessageTransferReqData.
+const goldenN1N2ReqDataJSON = `{"n1MessageContainer":{"n1MessageClass":"SM",` +
+	`"n1MessageContent":{"contentId":"GSM_NAS"}},` +
+	`"n2InfoContainer":{"n2InformationClass":"SM","smInfo":{"pduSessionId":10,` +
+	`"n2InfoContent":{"ngapIeType":"PDU_RES_SETUP_REQ",` +
+	`"ngapData":{"contentId":"N2SmInformation"}},` +
+	`"sNssai":{"sst":1,"sd":"112232"}}},"pduSessionId":10}`
+
+// newTestN1N2MessageTransferReqData mirrors how the SMF fills the JsonData of
+// N1N2MessageTransfer in sendPDUSessionEstablishmentAccept
+// (internal/sbi/processor/datapath.go).
+func newTestN1N2MessageTransferReqData() *models.N1N2MessageTransferReqData {
+	return &models.N1N2MessageTransferReqData{
+		PduSessionId: 10,
+		N1MessageContainer: &models.N1MessageContainer{
+			N1MessageClass:   "SM",
+			N1MessageContent: &models.RefToBinaryData{ContentId: testN1ContentID},
+		},
+		N2InfoContainer: &models.N2InfoContainer{
+			N2InformationClass: models.N2InformationClass_SM,
+			SmInfo: &models.N2SmInformation{
+				PduSessionId: 10,
+				N2InfoContent: &models.N2InfoContent{
+					NgapIeType: models.AmfCommunicationNgapIeType_PDU_RES_SETUP_REQ,
+					NgapData: &models.RefToBinaryData{
+						ContentId: testN2ContentID,
+					},
+				},
+				SNssai: &models.Snssai{Sst: 1, Sd: "112232"},
+			},
+		},
+	}
+}
+
+// extractBoundary pulls the random boundary out of a MultipartEncode content type.
+func extractBoundary(t *testing.T, contentType string) string {
+	t.Helper()
+	require.True(t, strings.HasPrefix(contentType, multipartCTPrefix))
+	require.True(t, strings.HasSuffix(contentType, `"`))
+	return contentType[len(multipartCTPrefix) : len(contentType)-1]
+}
+
+func TestGoldenN1N2MessageTransferReqDataJSON(t *testing.T) {
+	b, err := openapi.Serialize(newTestN1N2MessageTransferReqData(), jsonMediaType)
+	require.NoError(t, err)
+
+	// double-encode guard
+	b2, err := openapi.Serialize(newTestN1N2MessageTransferReqData(), jsonMediaType)
+	require.NoError(t, err)
+	require.Equal(t, b, b2)
+
+	require.Equal(t, goldenN1N2ReqDataJSON, string(b))
+
+	// decode-back check
+	var decoded models.N1N2MessageTransferReqData
+	require.NoError(t, openapi.Deserialize(&decoded, []byte(goldenN1N2ReqDataJSON), jsonMediaType))
+	require.Equal(t, *newTestN1N2MessageTransferReqData(), decoded)
+}
+
+func TestGoldenN1N2MessageTransferRequestMultipart(t *testing.T) {
+	newRequest := func() models.N1N2MessageTransferRequest {
+		return models.N1N2MessageTransferRequest{
+			JsonData: newTestN1N2MessageTransferReqData(),
+			// golden bytes of BuildGSMPDUSessionEstablishmentReject
+			// (internal/context/gsm_build_internal_test.go)
+			BinaryDataN1Message: []byte{0x2e, 0x0a, 0x01, 0xc3, 0x26},
+			// golden bytes of BuildPDUSessionResourceModifyConfirmTransfer
+			// (internal/context/ngap_build_internal_test.go)
+			BinaryDataN2Information: []byte{
+				0x00, 0x00, 0x40, 0x3e, 0xc0, 0xa8, 0xb3, 0x01, 0x00, 0x00, 0x01, 0x03,
+			},
+		}
+	}
+
+	golden := strings.Join([]string{
+		"--BOUNDARY",
+		"Content-Type: application/json",
+		"",
+		goldenN1N2ReqDataJSON,
+		"--BOUNDARY",
+		"Content-Id: GSM_NAS",
+		"Content-Type: application/vnd.3gpp.5gnas",
+		"",
+		"\x2e\x0a\x01\xc3\x26",
+		"--BOUNDARY",
+		"Content-Id: N2SmInformation",
+		"Content-Type: application/vnd.3gpp.ngap",
+		"",
+		"\x00\x00\x40\x3e\xc0\xa8\xb3\x01\x00\x00\x01\x03",
+		"--BOUNDARY--",
+		"",
+	}, "\r\n")
+
+	req := newRequest()
+	buf := &bytes.Buffer{}
+	contentType, err := openapi.MultipartEncode(&req, buf)
+	require.NoError(t, err)
+
+	// the multipart boundary is random: normalize it before comparing
+	boundary := extractBoundary(t, contentType)
+	norm := strings.ReplaceAll(buf.String(), boundary, "BOUNDARY")
+
+	// double-encode guard (on normalized output: only the boundary may differ)
+	req2 := newRequest()
+	buf2 := &bytes.Buffer{}
+	contentType2, err := openapi.MultipartEncode(&req2, buf2)
+	require.NoError(t, err)
+	boundary2 := extractBoundary(t, contentType2)
+	require.Equal(t, norm, strings.ReplaceAll(buf2.String(), boundary2, "BOUNDARY"))
+
+	require.Equal(t, golden, norm)
+
+	// decode-back: same core path as the server side's multipart binding
+	var decoded models.N1N2MessageTransferRequest
+	require.NoError(t, openapi.Deserialize(&decoded, buf.Bytes(), contentType))
+	require.Equal(t, req, decoded)
+}

--- a/internal/sbi/processor/openapi_response_golden_test.go
+++ b/internal/sbi/processor/openapi_response_golden_test.go
@@ -1,0 +1,140 @@
+package processor_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/free5gc/openapi"
+	"github.com/free5gc/openapi/models"
+)
+
+const (
+	testJSONMediaType     = "application/json"
+	testMultipartCTPrefix = `multipart/related; boundary="`
+)
+
+// goldenSmContextUpdatedDataJSON is the golden JSON encoding of newTestSmContextUpdatedData.
+const goldenSmContextUpdatedDataJSON = `{"upCnxState":"DEACTIVATED",` +
+	`"n1SmMsg":{"contentId":"PDUSessionReleaseCommand"},` +
+	`"n2SmInfo":{"contentId":"PDUResourceReleaseCommand"},` +
+	`"n2SmInfoType":"PDU_RES_REL_CMD"}`
+
+// newTestSmContextUpdatedData mirrors the UpdateSmContext 200 response the SMF
+// builds on the PDU session release path
+// (internal/sbi/processor/pdu_session.go, HandlePDUSessionSMContextUpdate).
+func newTestSmContextUpdatedData() *models.SmContextUpdatedData {
+	return &models.SmContextUpdatedData{
+		UpCnxState:   models.UpCnxState_DEACTIVATED,
+		N1SmMsg:      &models.RefToBinaryData{ContentId: "PDUSessionReleaseCommand"},
+		N2SmInfoType: models.N2SmInfoType_PDU_RES_REL_CMD,
+		N2SmInfo:     &models.RefToBinaryData{ContentId: "PDUResourceReleaseCommand"},
+	}
+}
+
+func TestGoldenSmContextCreatedDataJSON(t *testing.T) {
+	// shape of SMContext.BuildCreatedData (internal/context/sm_context.go),
+	// the JsonData of the PostSmContexts 201 response
+	newCreatedData := func() *models.SmfPduSessionSmContextCreatedData {
+		return &models.SmfPduSessionSmContextCreatedData{
+			SNssai: &models.Snssai{Sst: 1, Sd: "112232"},
+		}
+	}
+
+	golden := `{"sNssai":{"sst":1,"sd":"112232"}}`
+
+	b, err := openapi.Serialize(newCreatedData(), testJSONMediaType)
+	require.NoError(t, err)
+
+	// double-encode guard
+	b2, err := openapi.Serialize(newCreatedData(), testJSONMediaType)
+	require.NoError(t, err)
+	require.Equal(t, b, b2)
+
+	require.Equal(t, golden, string(b))
+
+	// decode-back check
+	var decoded models.SmfPduSessionSmContextCreatedData
+	require.NoError(t, openapi.Deserialize(&decoded, []byte(golden), testJSONMediaType))
+	require.Equal(t, *newCreatedData(), decoded)
+}
+
+func TestGoldenSmContextUpdatedDataJSON(t *testing.T) {
+	b, err := openapi.Serialize(newTestSmContextUpdatedData(), testJSONMediaType)
+	require.NoError(t, err)
+
+	// double-encode guard
+	b2, err := openapi.Serialize(newTestSmContextUpdatedData(), testJSONMediaType)
+	require.NoError(t, err)
+	require.Equal(t, b, b2)
+
+	require.Equal(t, goldenSmContextUpdatedDataJSON, string(b))
+
+	// decode-back check
+	var decoded models.SmContextUpdatedData
+	require.NoError(t, openapi.Deserialize(&decoded, []byte(goldenSmContextUpdatedDataJSON), testJSONMediaType))
+	require.Equal(t, *newTestSmContextUpdatedData(), decoded)
+}
+
+func TestGoldenUpdateSmContextResponse200Multipart(t *testing.T) {
+	newResponse := func() models.UpdateSmContextResponse200 {
+		return models.UpdateSmContextResponse200{
+			JsonData: newTestSmContextUpdatedData(),
+			// golden bytes of BuildGSMPDUSessionReleaseCommand (network-triggered)
+			// (internal/context/gsm_build_internal_test.go)
+			BinaryDataN1SmMessage: []byte{0x2e, 0x0a, 0x00, 0xd3, 0x24},
+			// golden bytes of BuildPDUSessionResourceReleaseCommandTransfer
+			// (internal/context/ngap_build_internal_test.go)
+			BinaryDataN2SmInformation: []byte{0x10},
+		}
+	}
+
+	golden := strings.Join([]string{
+		"--BOUNDARY",
+		"Content-Type: application/json",
+		"",
+		goldenSmContextUpdatedDataJSON,
+		"--BOUNDARY",
+		"Content-Id: PDUSessionReleaseCommand",
+		"Content-Type: application/vnd.3gpp.5gnas",
+		"",
+		"\x2e\x0a\x00\xd3\x24",
+		"--BOUNDARY",
+		"Content-Id: PDUResourceReleaseCommand",
+		"Content-Type: application/vnd.3gpp.ngap",
+		"",
+		"\x10",
+		"--BOUNDARY--",
+		"",
+	}, "\r\n")
+
+	resp := newResponse()
+	buf := &bytes.Buffer{}
+	contentType, err := openapi.MultipartEncode(&resp, buf)
+	require.NoError(t, err)
+
+	// the multipart boundary is random: normalize it before comparing.
+	// The server render path (openapi.MultipartRelatedRender) calls the same
+	// MultipartEncode, so this test covers the response wire format.
+	require.True(t, strings.HasPrefix(contentType, testMultipartCTPrefix))
+	require.True(t, strings.HasSuffix(contentType, `"`))
+	boundary := contentType[len(testMultipartCTPrefix) : len(contentType)-1]
+	norm := strings.ReplaceAll(buf.String(), boundary, "BOUNDARY")
+
+	// double-encode guard (on normalized output: only the boundary may differ)
+	resp2 := newResponse()
+	buf2 := &bytes.Buffer{}
+	contentType2, err := openapi.MultipartEncode(&resp2, buf2)
+	require.NoError(t, err)
+	boundary2 := contentType2[len(testMultipartCTPrefix) : len(contentType2)-1]
+	require.Equal(t, norm, strings.ReplaceAll(buf2.String(), boundary2, "BOUNDARY"))
+
+	require.Equal(t, golden, norm)
+
+	// decode-back round-trip
+	var decoded models.UpdateSmContextResponse200
+	require.NoError(t, openapi.Deserialize(&decoded, buf.Bytes(), contentType))
+	require.Equal(t, resp, decoded)
+}


### PR DESCRIPTION
## What

Adds byte-exact **golden tests** for the SMF message builders and openapi serialization. **Test files only — no production code changes.**

Covered:
- GSM builders (PDU Session Establishment Accept/Reject, Release Command, Modification Command/Reject, ...)
- NGAP transfer builders (PDU Session Resource Setup/Modify/Release, Path Switch Ack/Unsuccessful, Handover, ...)
- openapi JSON and multipart/related request & response bodies

## Why

Freeze the current wire format as a baseline **before** the upcoming nas / ngap / openapi module upgrade. The frozen golden bytes let the upgrade be verified byte-for-byte, so any wire-format change becomes an explicit, reviewed decision instead of a silent regression.

## Notes

Golden tests are deterministic and fixtures avoid map-iteration / TEID-generator nondeterminism, and every case includes a double-encode guard and a decode-back check.