### PR TITLE
fix: make pfcp handler log tests timezone-agnostic

### DIFF
--- a/internal/pfcp/handler/handler_test.go
+++ b/internal/pfcp/handler/handler_test.go
@@ -34,7 +34,7 @@ func (lc *LogCapture) String() string {
 // }
 
 func TestHandlePfcpManagementRequest(t *testing.T) {
-	re := regexp.MustCompile(`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z)(.*)`)
+	re := regexp.MustCompile(`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}(?:Z|[+-]\d{2}:\d{2}))(.*)`)
 	Convey("Test log message", t, func() {
 		remoteAddr := &net.UDPAddr{}
 		testPfcpReq := &pfcp.Message{}
@@ -53,7 +53,7 @@ func TestHandlePfcpManagementRequest(t *testing.T) {
 }
 
 func TestHandlePfcpAssociationSetupRequest(t *testing.T) {
-	re := regexp.MustCompile(`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z)(.*)`)
+	re := regexp.MustCompile(`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}(?:Z|[+-]\d{2}:\d{2}))(.*)`)
 	re2 := regexp.MustCompile(`(.*)\n(.*)`)
 	Convey("Test if NodeID is Nil", t, func() {
 		remoteAddr := &net.UDPAddr{
@@ -143,7 +143,7 @@ func TestHandlePfcpAssociationSetupRequest(t *testing.T) {
 }
 
 func TestHandlePfcpAssociationUpdateRequest(t *testing.T) {
-	re := regexp.MustCompile(`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z)(.*)`)
+	re := regexp.MustCompile(`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}(?:Z|[+-]\d{2}:\d{2}))(.*)`)
 	Convey("Test logger message", t, func() {
 		remoteAddr := &net.UDPAddr{}
 		testPfcpReq := &pfcp.Message{}


### PR DESCRIPTION
The three TestHandlePfcp{Management,AssociationSetup,AssociationUpdate} Request tests parsed captured log lines with a timestamp regex that only matched a UTC "Z" suffix (\.\d{9}Z). free5gc's logger emits local-time RFC3339Nano timestamps, so on a non-UTC machine the offset form (e.g. +08:00) fails to match, FindStringSubmatch returns nil, and capturedLogs[2] panics with "index out of range [2] with length 0".

Accept either a Z or a numeric ±HH:MM offset in the timestamp so the tests pass regardless of the host timezone (UTC CI and local alike). Test-only change.