### PR TITLE
fix: avoid nil pointer dereference when plmnList is not configured

### DIFF
--- a/internal/sbi/consumer/nrf_service.go
+++ b/internal/sbi/consumer/nrf_service.go
@@ -154,7 +154,10 @@ func (s *nnrfService) buildNfProfile(smfContext *smf_context.SMFContext) (
 		NfServices:    *smfProfile.NFServices,
 		SmfInfo:       smfProfile.SMFInfo,
 		SNssais:       sNssais,
-		PlmnList:      *smfProfile.PLMNList,
+	}
+	// plmnList is optional in the config, only set it when it is configured
+	if smfProfile.PLMNList != nil {
+		profile.PlmnList = *smfProfile.PLMNList
 	}
 	if smfContext.Locality != "" {
 		profile.Locality = smfContext.Locality


### PR DESCRIPTION
fixing https://github.com/free5gc/free5gc/issues/1105

This pull request makes a change to how the `PlmnList` field is set in the `buildNfProfile` function. Now, `PlmnList` is only set if it is configured, ensuring that the field remains unset when not present in the config.

- `internal/sbi/consumer/nrf_service.go`: Updated the `buildNfProfile` function to only set `PlmnList` when it is configured, making the field truly optional.

`plmnList` is a conditional attribute in the NFProfile (TS 29.510, Table 6.1.6.2.2-1): it shall be present if this information is available for the NF, and if it is not provided, the PLMN ID(s) of the PLMN of the NRF are assumed for the NF.