### PR TITLE
fix: avoid deleting the canonical reference of a newer SM context

### DIFF
--- a/internal/context/sm_context.go
+++ b/internal/context/sm_context.go
@@ -423,10 +423,12 @@ func RemoveSMContext(ref string) {
 	smContext.NrdcIndicator = false
 
 	smContextPool.Delete(ref)
-	// Only drop the canonical reference if it still points to this SM context. A newer
-	// SM context for the same UE and PDU session may already have taken over the name,
-	// and deleting it would leave that context unreachable, leaking its UE IP address.
-	canonicalRef.CompareAndDelete(canonicalName(smContext.Supi, smContext.PDUSessionID), ref)
+	// Identifier is the id NewSMContext stored the canonical reference under, so it is
+	// the only field guaranteed to rebuild the same name. Only drop the reference if it
+	// still points to this SM context: a newer SM context for the same UE and PDU
+	// session may already have taken over the name, and deleting it would leave that
+	// context unreachable, leaking its UE IP address.
+	canonicalRef.CompareAndDelete(canonicalName(smContext.Identifier, smContext.PDUSessionID), ref)
 	smContext.Log.Infof("smContext[%s] is deleted from pool", ref)
 }
 

--- a/internal/context/sm_context.go
+++ b/internal/context/sm_context.go
@@ -423,7 +423,10 @@ func RemoveSMContext(ref string) {
 	smContext.NrdcIndicator = false
 
 	smContextPool.Delete(ref)
-	canonicalRef.Delete(canonicalName(smContext.Supi, smContext.PDUSessionID))
+	// Only drop the canonical reference if it still points to this SM context. A newer
+	// SM context for the same UE and PDU session may already have taken over the name,
+	// and deleting it would leave that context unreachable, leaking its UE IP address.
+	canonicalRef.CompareAndDelete(canonicalName(smContext.Supi, smContext.PDUSessionID), ref)
 	smContext.Log.Infof("smContext[%s] is deleted from pool", ref)
 }
 

--- a/internal/context/sm_context_test.go
+++ b/internal/context/sm_context_test.go
@@ -1,0 +1,50 @@
+package context_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/smf/internal/context"
+)
+
+// A stale SM context must not remove the canonical reference of the SM context that
+// replaced it, otherwise the newer one becomes unreachable and leaks its UE IP address.
+func TestRemoveSMContextKeepsCanonicalRefOfNewerSMContext(t *testing.T) {
+	initConfig()
+
+	const (
+		supi         = "imsi-001016100000041"
+		pduSessionID = int32(1)
+	)
+
+	newSMContextForSupi := func() *context.SMContext {
+		smContext := context.NewSMContext(supi, pduSessionID)
+		require.NotNil(t, smContext)
+		// HandlePDUSessionSMContextCreate attaches the create data right after
+		// NewSMContext; RemoveSMContext reads Supi out of it.
+		smContext.SmfPduSessionSmContextCreateData = &models.SmfPduSessionSmContextCreateData{
+			Supi:         supi,
+			PduSessionId: pduSessionID,
+		}
+		return smContext
+	}
+
+	oldSMContext := newSMContextForSupi()
+	newSMContext := newSMContextForSupi()
+	require.NotEqual(t, oldSMContext.Ref, newSMContext.Ref)
+
+	// NewSMContext has already handed the canonical name over to newSMContext.
+	require.Equal(t, newSMContext, context.GetSMContextById(supi, pduSessionID))
+
+	context.RemoveSMContext(oldSMContext.Ref)
+
+	require.Nil(t, context.GetSMContextByRef(oldSMContext.Ref))
+	require.Equal(t, newSMContext, context.GetSMContextById(supi, pduSessionID),
+		"removing the stale SM context must not detach the newer one from its canonical name")
+
+	// The owner of the canonical name still cleans it up.
+	context.RemoveSMContext(newSMContext.Ref)
+	require.Nil(t, context.GetSMContextById(supi, pduSessionID))
+}

--- a/internal/context/sm_context_test.go
+++ b/internal/context/sm_context_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/free5gc/openapi/models"
 	"github.com/free5gc/smf/internal/context"
 )
 
@@ -19,20 +18,10 @@ func TestRemoveSMContextKeepsCanonicalRefOfNewerSMContext(t *testing.T) {
 		pduSessionID = int32(1)
 	)
 
-	newSMContextForSupi := func() *context.SMContext {
-		smContext := context.NewSMContext(supi, pduSessionID)
-		require.NotNil(t, smContext)
-		// HandlePDUSessionSMContextCreate attaches the create data right after
-		// NewSMContext; RemoveSMContext reads Supi out of it.
-		smContext.SmfPduSessionSmContextCreateData = &models.SmfPduSessionSmContextCreateData{
-			Supi:         supi,
-			PduSessionId: pduSessionID,
-		}
-		return smContext
-	}
-
-	oldSMContext := newSMContextForSupi()
-	newSMContext := newSMContextForSupi()
+	oldSMContext := context.NewSMContext(supi, pduSessionID)
+	require.NotNil(t, oldSMContext)
+	newSMContext := context.NewSMContext(supi, pduSessionID)
+	require.NotNil(t, newSMContext)
 	require.NotEqual(t, oldSMContext.Ref, newSMContext.Ref)
 
 	// NewSMContext has already handed the canonical name over to newSMContext.


### PR DESCRIPTION
fixing https://github.com/free5gc/free5gc/issues/1112

This pull request addresses a potential resource leak in the SM context management logic and adds a test to ensure correct behavior when removing SM contexts. The main focus is to prevent stale SM contexts from deleting canonical references that belong to newer contexts, which could otherwise result in unreachable SM contexts and leaked UE IP addresses.

**Bug fix to SM context removal logic:**

* Updated `RemoveSMContext` in `sm_context.go` to use `CompareAndDelete` for canonical references, ensuring that only the SM context that still owns the canonical name can remove it. This prevents newer SM contexts from becoming unreachable if a stale context is deleted.

**Testing improvements:**

* Added a new test `TestRemoveSMContextKeepsCanonicalRefOfNewerSMContext` in `sm_context_test.go` to verify that removing a stale SM context does not remove the canonical reference of a newer SM context, preventing resource leaks.